### PR TITLE
Add RPC server and ledger helpers

### DIFF
--- a/validator_py/__init__.py
+++ b/validator_py/__init__.py
@@ -1,1 +1,20 @@
-# Python-based validator prototype
+"""Simplified Python validator components."""
+
+from .validator import Validator
+from .ledger import Ledger
+from .crypto import generate_keypair, sign, verify, poh_hash
+from .transaction import Transaction
+from .network import GossipNode
+from .rpc import RPCServer
+
+__all__ = [
+    "Validator",
+    "Ledger",
+    "Transaction",
+    "generate_keypair",
+    "sign",
+    "verify",
+    "poh_hash",
+    "GossipNode",
+    "RPCServer",
+]

--- a/validator_py/crypto.py
+++ b/validator_py/crypto.py
@@ -1,0 +1,22 @@
+import hashlib
+import hmac
+import os
+
+class SimpleKeypair:
+    def __init__(self, private_key: bytes):
+        self.private_key = private_key
+        self.public_key = private_key  # Placeholder for symmetric key
+
+def generate_keypair() -> SimpleKeypair:
+    return SimpleKeypair(os.urandom(32))
+
+def sign(message: bytes, keypair: SimpleKeypair) -> bytes:
+    return hmac.new(keypair.private_key, message, hashlib.sha256).digest()
+
+def verify(message: bytes, signature: bytes, keypair: SimpleKeypair) -> bool:
+    expected = hmac.new(keypair.private_key, message, hashlib.sha256).digest()
+    return hmac.compare_digest(expected, signature)
+
+
+def poh_hash(prev_hash: bytes, data: bytes) -> bytes:
+    return hashlib.sha256(prev_hash + data).digest()

--- a/validator_py/ledger.py
+++ b/validator_py/ledger.py
@@ -1,0 +1,27 @@
+from typing import Dict
+from .crypto import verify
+from .transaction import Transaction
+
+class Ledger:
+    def __init__(self):
+        self.balances: Dict[str, int] = {}
+        self.history = []
+
+    def create_account(self, owner: str, balance: int = 0) -> None:
+        """Create a new account with the given balance."""
+        if owner not in self.balances:
+            self.balances[owner] = balance
+
+    def get_balance(self, owner: str) -> int:
+        """Return the current balance for an owner."""
+        return self.balances.get(owner, 0)
+
+    def process_transaction(self, tx: Transaction) -> bool:
+        payload = f"{tx.sender}->{tx.receiver}:{tx.amount}".encode()
+        keypair_like = type("KP", (), {"private_key": bytes.fromhex(tx.sender)})()
+        if not verify(payload, tx.signature, keypair_like):
+            return False
+        self.balances[tx.sender] = self.balances.get(tx.sender, 0) - tx.amount
+        self.balances[tx.receiver] = self.balances.get(tx.receiver, 0) + tx.amount
+        self.history.append(tx)
+        return True

--- a/validator_py/network.py
+++ b/validator_py/network.py
@@ -1,0 +1,34 @@
+import asyncio
+from typing import Set
+
+class GossipNode:
+    def __init__(self, host: str, port: int):
+        self.host = host
+        self.port = port
+        self.peers: Set[tuple[str, int]] = set()
+        self.server = None
+
+    async def start(self):
+        self.server = await asyncio.start_server(self.handle_conn, self.host, self.port)
+        await self.server.start_serving()
+
+    async def handle_conn(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        data = await reader.read(1024)
+        writer.close()
+        await writer.wait_closed()
+        await self.broadcast(data)
+
+    async def broadcast(self, data: bytes) -> None:
+        for peer in list(self.peers):
+            try:
+                r, w = await asyncio.open_connection(*peer)
+                w.write(data)
+                await w.drain()
+                w.close()
+                await w.wait_closed()
+            except Exception:
+                pass
+
+    def add_peer(self, host: str, port: int):
+        """Add a peer to the gossip set."""
+        self.peers.add((host, port))

--- a/validator_py/rpc.py
+++ b/validator_py/rpc.py
@@ -1,0 +1,44 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+
+class RPCHandler(BaseHTTPRequestHandler):
+    ledger = None
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/balance":
+            params = parse_qs(parsed.query)
+            acct = params.get("account", [None])[0]
+            if acct is None:
+                self.send_response(400)
+                self.end_headers()
+                return
+            bal = self.ledger.get_balance(acct)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"balance": bal}).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+class RPCServer:
+    def __init__(self, ledger, host="127.0.0.1", port=8899):
+        self.ledger = ledger
+        self.host = host
+        self.port = port
+        self.httpd = None
+        self.thread = None
+
+    def start(self):
+        handler = type("_H", (RPCHandler,), {"ledger": self.ledger})
+        self.httpd = HTTPServer((self.host, self.port), handler)
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    def stop(self):
+        if self.httpd:
+            self.httpd.shutdown()
+            self.thread.join()

--- a/validator_py/transaction.py
+++ b/validator_py/transaction.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from .crypto import SimpleKeypair, sign
+
+@dataclass
+class Transaction:
+    sender: str
+    receiver: str
+    amount: int
+    signature: bytes
+
+    @classmethod
+    def create(cls, sender_kp: SimpleKeypair, receiver: str, amount: int) -> "Transaction":
+        payload = f"{sender_kp.public_key.hex()}->{receiver}:{amount}".encode()
+        signature = sign(payload, sender_kp)
+        return cls(sender_kp.public_key.hex(), receiver, amount, signature)

--- a/validator_py/validator.py
+++ b/validator_py/validator.py
@@ -1,21 +1,51 @@
 import asyncio
 from .fast_utils import fast_hash
+from .crypto import generate_keypair, sign, verify, poh_hash
+from .ledger import Ledger
+from .network import GossipNode
+from .rpc import RPCServer
+from .transaction import Transaction
 
 class Validator:
-    def __init__(self):
+    def __init__(self, host: str = "127.0.0.1", port: int = 8000, rpc_port: int = 8899):
+        """Initialize the validator with networking and RPC endpoints."""
+        self.ledger = Ledger()
+        self.node = GossipNode(host, port)
+        self.rpc = RPCServer(self.ledger, host, rpc_port)
         self.blocks = []
+        self.prev_hash = b"0" * 32
+        self.keypair = generate_keypair()
 
-    async def validate_block(self, block_data: bytes) -> int:
-        """Validate a block and return its hash."""
+    async def start(self):
+        await self.node.start()
+        self.rpc.start()
+
+    async def stop(self):
+        if self.rpc:
+            self.rpc.stop()
+
+    def add_peer(self, host: str, port: int):
+        self.node.add_peer(host, port)
+
+    async def validate_block(self, block_data: bytes) -> bytes:
         block_hash = fast_hash(block_data)
-        self.blocks.append(block_hash)
-        return block_hash
+        poh = poh_hash(self.prev_hash, block_hash.to_bytes(8, "big"))
+        self.prev_hash = poh
+        self.blocks.append(poh)
+        return poh
+
+    async def process_transaction(self, tx: Transaction):
+        if self.ledger.process_transaction(tx):
+            msg = f"TX:{tx.sender}->{tx.receiver}:{tx.amount}".encode()
+            await self.node.broadcast(msg)
 
 async def main():
     v = Validator()
-    data = b"example block"
-    h = await v.validate_block(data)
-    print("Validated block hash:", h)
+    await v.start()
+    tx = Transaction.create(v.keypair, "receiver", 10)
+    await v.process_transaction(tx)
+    h = await v.validate_block(b"example block")
+    print("PoH hash:", h.hex())
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- extend ledger with helper methods
- expose a simple RPC server
- add broadcast helper in gossip network
- wire RPC into validator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb393ada083209726748e98212bd9