### PR TITLE
Expand python stubs

### DIFF
--- a/python_stubs/thin_client/__init__.py
+++ b/python_stubs/thin_client/__init__.py
@@ -1,4 +1,67 @@
-"""Python stub for crate `thin-client`."""
+"""Minimal Python implementation mirroring the Rust ``thin-client`` crate.
 
-class Placeholder:
-    pass
+This module exposes a :class:`ThinClient` class that communicates with a
+validator's RPC endpoint and TPU (transaction processing unit).  The real Rust
+implementation performs heavy networking and concurrency.  The Python version
+sketches the same API using :mod:`asyncio` for asynchronous operations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+@dataclass
+class ClientOptimizer:
+    """Very small stand in for the Rust optimizer used to rotate RPC clients."""
+
+    index: int = 0
+
+    def best(self) -> int:
+        return self.index
+
+
+class ThinClient:
+    """Communicates with the RPC service and the TPU.
+
+    Parameters mirror the Rust constructor.  Networking is done lazily using
+    ``asyncio`` so calls such as :py:meth:`send_transaction` return ``awaitable``
+    objects.
+    """
+
+    def __init__(self, rpc_addr: str, tpu_addr: str) -> None:
+        self.rpc_addr = rpc_addr
+        self.tpu_addr = tpu_addr
+        self._optimizer = ClientOptimizer()
+
+    async def get_latest_blockhash(self) -> str:
+        """Return a dummy blockhash.
+
+        A real implementation would perform an RPC request.  The async nature
+        mirrors the network bound Rust version.
+        """
+
+        await asyncio.sleep(0)
+        return "BLOCKHASH"
+
+    async def send_transaction(self, tx_bytes: bytes) -> str:
+        """Send a transaction to the TPU.
+
+        The real crate sends the binary representation of a transaction over
+        UDP or QUIC.  Here we simply simulate the delay.
+        """
+
+        await asyncio.sleep(0)
+        # Return dummy signature
+        return "SIGNATURE"
+
+    async def send_batch(self, batch: Iterable[bytes]) -> None:
+        """Send many transactions in parallel."""
+
+        await asyncio.gather(*(self.send_transaction(tx) for tx in batch))
+
+
+__all__ = ["ThinClient", "ClientOptimizer"]
+

--- a/python_stubs/thread_manager/__init__.py
+++ b/python_stubs/thread_manager/__init__.py
@@ -1,4 +1,56 @@
-"""Python stub for crate `thread-manager`."""
+"""Simplified thread pool utilities inspired by the Rust ``thread-manager``.
 
-class Placeholder:
-    pass
+The Rust crate exposes helpers for spawning work on native threads, tokio
+executors and rayon pools.  The Python version provides a thin abstraction over
+``concurrent.futures`` and ``asyncio``.  It is *not* a drop in replacement but
+offers a familiar API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+
+
+@dataclass
+class ThreadManagerConfig:
+    """Configuration describing thread pools and event loops."""
+
+    max_threads: int = 4
+    use_asyncio: bool = True
+
+
+class ThreadManager:
+    """Create and manage named thread pools."""
+
+    def __init__(self, config: Optional[ThreadManagerConfig] = None) -> None:
+        self.config = config or ThreadManagerConfig()
+        self._pools: Dict[str, ThreadPoolExecutor] = {}
+        if self.config.use_asyncio:
+            self._loop = asyncio.new_event_loop()
+        else:
+            self._loop = None
+
+    def get_pool(self, name: str) -> ThreadPoolExecutor:
+        if name not in self._pools:
+            self._pools[name] = ThreadPoolExecutor(max_workers=self.config.max_threads)
+        return self._pools[name]
+
+    def spawn(self, func: Callable[..., Any], *args: Any, pool: str = "default", **kwargs: Any) -> Any:
+        """Execute ``func`` in the specified pool."""
+
+        executor = self.get_pool(pool)
+        return executor.submit(func, *args, **kwargs)
+
+    async def run_async(self, coro: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Run an asynchronous coroutine on the manager event loop."""
+
+        if not self._loop:
+            raise RuntimeError("asyncio disabled in configuration")
+        return await coro(*args, **kwargs)
+
+
+__all__ = ["ThreadManager", "ThreadManagerConfig"]
+

--- a/python_stubs/timings/__init__.py
+++ b/python_stubs/timings/__init__.py
@@ -1,4 +1,45 @@
-"""Python stub for crate `timings`."""
+"""Lightweight helpers for tracking execution timings.
 
-class Placeholder:
-    pass
+The original Rust crate collects per-program metrics during transaction
+execution.  The Python translation merely stores counters and durations.  It can
+be used to measure high level performance of simulated workloads.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Dict
+
+
+class ExecuteTimingType(Enum):
+    """High level phases of transaction execution."""
+
+    CHECK_US = auto()
+    LOAD_US = auto()
+    EXECUTE_US = auto()
+    STORE_US = auto()
+
+
+@dataclass
+class Metrics:
+    """Simple metric accumulator."""
+
+    values: Dict[ExecuteTimingType, int] = field(default_factory=dict)
+
+    def increment(self, t: ExecuteTimingType, delta: int) -> None:
+        self.values[t] = self.values.get(t, 0) + delta
+
+
+@dataclass
+class ProgramTiming:
+    accumulated_us: int = 0
+    count: int = 0
+
+    def record(self, duration_us: int) -> None:
+        self.accumulated_us += duration_us
+        self.count += 1
+
+
+__all__ = ["ProgramTiming", "Metrics", "ExecuteTimingType"]
+

--- a/python_stubs/tls_utils/__init__.py
+++ b/python_stubs/tls_utils/__init__.py
@@ -1,4 +1,46 @@
-"""Python stub for crate `tls-utils`."""
+"""Helpers for creating TLS contexts similar to the Rust ``tls-utils`` crate."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import ssl
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+def tls_client_context() -> ssl.SSLContext:
+    """Return an insecure :class:`ssl.SSLContext` used for client connections."""
+
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    return context
+
+
+def tls_server_context(certfile: str, keyfile: str) -> ssl.SSLContext:
+    """Return a simple server :class:`ssl.SSLContext`."""
+
+    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    context.load_cert_chain(certfile, keyfile)
+    return context
+
+
+@dataclass
+class QuicClientCertificate:
+    """Placeholder representing a QUIC client certificate."""
+
+    certificate: bytes
+    key: bytes
+
+    @classmethod
+    def generate(cls) -> "QuicClientCertificate":
+        """Return dummy certificate bytes."""
+
+        return cls(b"cert", b"key")
+
+
+__all__ = [
+    "tls_client_context",
+    "tls_server_context",
+    "QuicClientCertificate",
+]
+

--- a/python_stubs/tokens/__init__.py
+++ b/python_stubs/tokens/__init__.py
@@ -1,4 +1,37 @@
-"""Python stub for crate `tokens`."""
+"""High level token distribution helpers."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+@dataclass
+class SplTokenArgs:
+    token_account_address: str
+    mint: str
+    decimals: int = 0
+
+
+class TokenClient:
+    """Very small approximation of the Rust ``tokens`` CLI."""
+
+    def __init__(self, rpc_url: str) -> None:
+        self.rpc_url = rpc_url
+
+    def build_transfer_instructions(self, destination: str, amount: int, args: SplTokenArgs) -> list:
+        """Return an instruction-like structure describing a transfer."""
+
+        return [
+            {
+                "program": "spl-token",
+                "account": destination,
+                "amount": amount,
+                "mint": args.mint,
+                "decimals": args.decimals,
+            }
+        ]
+
+
+__all__ = ["TokenClient", "SplTokenArgs"]
+

--- a/python_stubs/tps_client/__init__.py
+++ b/python_stubs/tps_client/__init__.py
@@ -1,4 +1,33 @@
-"""Python stub for crate `tps-client`."""
+"""Client helpers for submitting transactions at high throughput."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+class TpsClientError(Exception):
+    """Base error for the TPS client."""
+
+
+class TpsClient:
+    """Asynchronous interface mirroring the Rust trait."""
+
+    def __init__(self, rpc_url: str) -> None:
+        self.rpc_url = rpc_url
+
+    async def send_transaction(self, tx: bytes) -> str:
+        await asyncio.sleep(0)
+        return "SIGNATURE"
+
+    async def send_batch(self, transactions: Iterable[bytes]) -> None:
+        await asyncio.gather(*(self.send_transaction(tx) for tx in transactions))
+
+    async def get_latest_blockhash(self) -> str:
+        await asyncio.sleep(0)
+        return "BLOCKHASH"
+
+
+__all__ = ["TpsClient", "TpsClientError"]
+

--- a/python_stubs/tpu_client/__init__.py
+++ b/python_stubs/tpu_client/__init__.py
@@ -1,4 +1,31 @@
-"""Python stub for crate `tpu-client`."""
+"""Asynchronous TPU client implementation sketch."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+
+@dataclass
+class TpuClientConfig:
+    fanout_slots: int = 12
+
+
+class TpuClient:
+    """Send transactions directly to a TPU endpoint using ``asyncio``."""
+
+    def __init__(self, rpc_url: str, websocket_url: str, config: TpuClientConfig | None = None) -> None:
+        self.rpc_url = rpc_url
+        self.websocket_url = websocket_url
+        self.config = config or TpuClientConfig()
+
+    async def send_transaction(self, tx: bytes) -> None:
+        # A real implementation would open a UDP/QUIC socket and send ``tx``
+        await asyncio.sleep(0)
+
+    async def send_batch(self, txs: list[bytes]) -> None:
+        await asyncio.gather(*(self.send_transaction(tx) for tx in txs))
+
+
+__all__ = ["TpuClient", "TpuClientConfig"]
+

--- a/python_stubs/tpu_client_next/__init__.py
+++ b/python_stubs/tpu_client_next/__init__.py
@@ -1,4 +1,32 @@
-"""Python stub for crate `tpu-client-next`."""
+"""Next generation TPU client abstractions."""
 
-class Placeholder:
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Dict, Iterable
+
+
+class ConnectionWorkersSchedulerError(Exception):
     pass
+
+
+class ConnectionWorkersScheduler:
+    """Distributes transactions across multiple worker connections."""
+
+    def __init__(self) -> None:
+        self.workers: Dict[str, asyncio.Queue[bytes]] = {}
+
+    async def register_worker(self, name: str) -> None:
+        self.workers[name] = asyncio.Queue()
+
+    async def dispatch(self, tx: bytes) -> None:
+        if not self.workers:
+            raise ConnectionWorkersSchedulerError("no workers registered")
+        # round robin for demonstration
+        worker = next(iter(self.workers.values()))
+        await worker.put(tx)
+
+
+__all__ = ["ConnectionWorkersScheduler", "ConnectionWorkersSchedulerError"]
+

--- a/python_stubs/transaction_context/__init__.py
+++ b/python_stubs/transaction_context/__init__.py
@@ -1,4 +1,31 @@
-"""Python stub for crate `transaction-context`."""
+"""Simplified transaction context data structures."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+IndexOfAccount = int
+
+
+@dataclass
+class InstructionAccount:
+    index_in_transaction: IndexOfAccount
+    is_signer: bool = False
+    is_writable: bool = False
+
+
+@dataclass
+class TransactionAccounts:
+    accounts: Dict[IndexOfAccount, Dict] = field(default_factory=dict)
+
+    def add(self, index: IndexOfAccount, account: Dict) -> None:
+        self.accounts[index] = account
+
+    def get(self, index: IndexOfAccount) -> Optional[Dict]:
+        return self.accounts.get(index)
+
+
+__all__ = ["InstructionAccount", "TransactionAccounts", "IndexOfAccount"]
+

--- a/python_stubs/transaction_dos/__init__.py
+++ b/python_stubs/transaction_dos/__init__.py
@@ -1,4 +1,26 @@
-"""Python stub for crate `transaction-dos`."""
+"""Minimal load generator used for stress testing."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import asyncio
+import argparse
+
+
+async def generate_load(rpc_url: str, iterations: int) -> None:
+    """Simulate sending many transactions."""
+
+    for _ in range(iterations):
+        await asyncio.sleep(0)  # network placeholder
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="transaction-dos tool")
+    parser.add_argument("--rpc-url", required=True)
+    parser.add_argument("--iterations", type=int, default=1)
+    args = parser.parse_args(argv)
+
+    asyncio.run(generate_load(args.rpc_url, args.iterations))
+
+
+__all__ = ["generate_load", "main"]
+

--- a/python_stubs/transaction_metrics_tracker/__init__.py
+++ b/python_stubs/transaction_metrics_tracker/__init__.py
@@ -1,4 +1,20 @@
-"""Python stub for crate `transaction-metrics-tracker`."""
+"""Helpers for deciding whether to record transaction metrics."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import os
+import random
+
+SIGNATURE_BYTES = 64
+_TXN_MASK = random.randrange(0, 4096)
+
+
+def should_track_transaction(signature: bytes) -> bool:
+    if len(signature) < SIGNATURE_BYTES:
+        return False
+    match_portion = int.from_bytes(signature[61:63], "little") >> 4
+    return match_portion == _TXN_MASK
+
+
+__all__ = ["should_track_transaction", "SIGNATURE_BYTES"]
+

--- a/python_stubs/transaction_status/__init__.py
+++ b/python_stubs/transaction_status/__init__.py
@@ -1,4 +1,24 @@
-"""Python stub for crate `transaction-status`."""
+"""Utilities for representing transaction status information."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import List
+
+
+class TransactionDetails(Enum):
+    FULL = auto()
+    SIGNATURES = auto()
+    NONE = auto()
+
+
+@dataclass
+class TransactionStatus:
+    signature: str
+    slot: int
+    err: bool = False
+
+
+__all__ = ["TransactionStatus", "TransactionDetails"]
+

--- a/python_stubs/transaction_status_client_types/__init__.py
+++ b/python_stubs/transaction_status_client_types/__init__.py
@@ -1,4 +1,15 @@
-"""Python stub for crate `transaction-status-client-types`."""
+"""Types shared by transaction status RPC clients."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+from enum import Enum, auto
+
+
+class UiTransactionEncoding(Enum):
+    BASE64 = auto()
+    BASE58 = auto()
+    JSON = auto()
+
+
+__all__ = ["UiTransactionEncoding"]
+

--- a/python_stubs/transaction_view/__init__.py
+++ b/python_stubs/transaction_view/__init__.py
@@ -1,4 +1,16 @@
-"""Python stub for crate `transaction-view`."""
+"""High level representation of a transaction and its message."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class TransactionView:
+    message: str
+    signatures: List[str]
+
+
+__all__ = ["TransactionView"]
+

--- a/python_stubs/turbine/__init__.py
+++ b/python_stubs/turbine/__init__.py
@@ -1,4 +1,21 @@
-"""Python stub for crate `turbine`."""
+"""Network data propagation utilities used by validators."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import asyncio
+
+
+class BroadcastStage:
+    """Simplified broadcast loop."""
+
+    def __init__(self) -> None:
+        self.queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+    async def broadcast(self) -> None:
+        while True:
+            data = await self.queue.get()
+            await asyncio.sleep(0)  # placeholder for network send
+
+
+__all__ = ["BroadcastStage"]
+

--- a/python_stubs/type_overrides/__init__.py
+++ b/python_stubs/type_overrides/__init__.py
@@ -1,4 +1,20 @@
-"""Python stub for crate `type-overrides`."""
+"""Wrapper modules used for test instrumentation."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import random
+import threading
+
+
+class rand:
+    randint = staticmethod(random.randint)
+    random = staticmethod(random.random)
+
+
+class thread:
+    Thread = threading.Thread
+    current_thread = staticmethod(threading.current_thread)
+
+
+__all__ = ["rand", "thread"]
+


### PR DESCRIPTION
## Summary
- fill out python implementations for multiple stub crates
- mirror thin-client behavior with asyncio
- provide small thread manager abstraction
- add token utilities and TLS helpers
- stub out tpu and tps clients
- include simple transaction context and status types

## Testing
- `python -m py_compile $(git ls-files "python_stubs/*.py" "python_stubs/*/__init__.py" | tr '\n' ' ')`

------
https://chatgpt.com/codex/tasks/task_e_685cdde502f0832090ee0fdd9f05c723