### PR TITLE
Fill stub Python modules

### DIFF
--- a/python_stubs/platform_tools_sdk_gen_headers/__init__.py
+++ b/python_stubs/platform_tools_sdk_gen_headers/__init__.py
@@ -1,4 +1,28 @@
-"""Python stub for crate `platform-tools-sdk/gen-headers`."""
+"""Utilities to generate C header files from small templates."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import os
+from typing import Mapping
+
+
+def generate_headers(definitions: Mapping[str, str], out_dir: str) -> None:
+    """Generate ``.h`` files from a mapping of names to contents.
+
+    Parameters
+    ----------
+    definitions : Mapping[str, str]
+        Mapping of header name (without extension) to header contents.
+    out_dir : str
+        Directory where generated files should be stored.
+    """
+
+    os.makedirs(out_dir, exist_ok=True)
+    for name, content in definitions.items():
+        path = os.path.join(out_dir, f"{name}.h")
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(content)
+
+
+__all__ = ["generate_headers"]
+

--- a/python_stubs/poh/__init__.py
+++ b/python_stubs/poh/__init__.py
@@ -1,4 +1,69 @@
-"""Python stub for crate `poh`."""
+"""Simplified Proof of History implementation.
 
-class Placeholder:
-    pass
+This module provides a small Python representation of the ``poh`` crate.  The
+real crate implements Solana's Proof of History mechanism.  The code below is
+not a full port; it merely offers a digest based chain so that other Python
+components can experiment with a PoH like API.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+
+@dataclass
+class ProofOfHistory:
+    """Minimal PoH recorder.
+
+    Parameters
+    ----------
+    seed : bytes, optional
+        Initial seed for the chain.  Defaults to ``b""``.
+    """
+
+    seed: bytes = b""
+    _chain: List[bytes] = field(default_factory=list, init=False)
+
+    def __post_init__(self) -> None:
+        self._last_hash = hashlib.sha256(self.seed).digest()
+
+    @property
+    def last_hash(self) -> bytes:
+        """Return the most recently generated hash."""
+
+        return self._last_hash
+
+    def record(self, data: bytes) -> bytes:
+        """Record ``data`` into the PoH chain.
+
+        Parameters
+        ----------
+        data : bytes
+            Arbitrary binary data to record.
+
+        Returns
+        -------
+        bytes
+            The newly computed hash.
+        """
+
+        digest = hashlib.sha256(self._last_hash + data).digest()
+        self._chain.append(digest)
+        self._last_hash = digest
+        return digest
+
+    def verify(self, data_stream: Iterable[bytes]) -> bool:
+        """Verify a stream of data matches the recorded chain."""
+
+        last = hashlib.sha256(self.seed).digest()
+        for expected, data in zip(self._chain, data_stream):
+            last = hashlib.sha256(last + data).digest()
+            if last != expected:
+                return False
+        return True
+
+
+__all__ = ["ProofOfHistory"]
+

--- a/python_stubs/poh_bench/__init__.py
+++ b/python_stubs/poh_bench/__init__.py
@@ -1,4 +1,34 @@
-"""Python stub for crate `poh-bench`."""
+"""Small benchmarking utilities for :mod:`poh`.
 
-class Placeholder:
-    pass
+The original crate exposes a command line application.  Here we provide the
+``benchmark_poh`` function which can be invoked manually from Python to emulate
+that behaviour.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Iterable
+
+from ..poh import ProofOfHistory
+
+
+def benchmark_poh(data_stream: Iterable[bytes], iterations: int = 1) -> float:
+    """Benchmark PoH verification.
+
+    The function records ``data_stream`` into a :class:`~poh.ProofOfHistory`
+    instance ``iterations`` times and measures the average duration in seconds.
+    """
+
+    start = time.perf_counter()
+    for _ in range(iterations):
+        poh = ProofOfHistory()
+        for item in data_stream:
+            poh.record(item)
+        poh.verify(data_stream)
+    end = time.perf_counter()
+    return (end - start) / max(iterations, 1)
+
+
+__all__ = ["benchmark_poh"]
+

--- a/python_stubs/poseidon/__init__.py
+++ b/python_stubs/poseidon/__init__.py
@@ -1,4 +1,25 @@
-"""Python stub for crate `poseidon`."""
+"""Simplified Poseidon hash implementation."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import hashlib
+from typing import Iterable
+
+
+def poseidon_hash(inputs: Iterable[bytes]) -> bytes:
+    """Compute a simple "Poseidon" style hash.
+
+    This is **not** the real Poseidon hash function; instead we simply
+    concatenate the inputs and feed them through SHA-256.  The real crate uses a
+    highly optimised cryptographic permutation which is outside the scope of
+    this repository.
+    """
+
+    hasher = hashlib.sha256()
+    for item in inputs:
+        hasher.update(item)
+    return hasher.digest()
+
+
+__all__ = ["poseidon_hash"]
+

--- a/python_stubs/precompiles/__init__.py
+++ b/python_stubs/precompiles/__init__.py
@@ -1,4 +1,28 @@
-"""Python stub for crate `precompiles`."""
+"""Basic precompile registry used during testing.
 
-class Placeholder:
-    pass
+The Rust crate includes micro-benchmarks for various precompile utilities.
+Benchmarking can be replicated in Python by timing calls to the registry.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+
+class PrecompileRegistry:
+    """Registry mapping names to Python callables."""
+
+    def __init__(self) -> None:
+        self._registry: Dict[str, Callable[..., object]] = {}
+
+    def register(self, name: str, func: Callable[..., object]) -> None:
+        self._registry[name] = func
+
+    def run(self, name: str, *args, **kwargs) -> object:
+        if name not in self._registry:
+            raise KeyError(f"Unknown precompile: {name}")
+        return self._registry[name](*args, **kwargs)
+
+
+__all__ = ["PrecompileRegistry"]
+

--- a/python_stubs/program_runtime/__init__.py
+++ b/python_stubs/program_runtime/__init__.py
@@ -1,4 +1,39 @@
-"""Python stub for crate `program-runtime`."""
+"""Minimal program runtime environment.
 
-class Placeholder:
-    pass
+The real ``program-runtime`` crate provides execution facilities for on-chain
+programs.  Here we implement a small in-memory dispatcher that can be used from
+Python unit tests.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Any
+
+
+class Program:
+    """Represents a small executable program."""
+
+    def __init__(self, func: Callable[[Any], Any]):
+        self.func = func
+
+    def run(self, arg: Any) -> Any:
+        return self.func(arg)
+
+
+class Runtime:
+    """Simple registry for :class:`Program` objects."""
+
+    def __init__(self) -> None:
+        self._programs: Dict[str, Program] = {}
+
+    def register(self, name: str, program: Program) -> None:
+        self._programs[name] = program
+
+    def invoke(self, name: str, arg: Any) -> Any:
+        if name not in self._programs:
+            raise KeyError(f"Program '{name}' not found")
+        return self._programs[name].run(arg)
+
+
+__all__ = ["Program", "Runtime"]
+

--- a/python_stubs/program_test/__init__.py
+++ b/python_stubs/program_test/__init__.py
@@ -1,4 +1,29 @@
-"""Python stub for crate `program-test`."""
+"""Utilities mirroring the ``program-test`` crate.
 
-class Placeholder:
-    pass
+The Rust crate offers a high level testing framework for on-chain programs.  In
+this simplified Python version tests can inherit from :class:`ProgramTestCase`
+to register and invoke small ``Program`` objects.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from ..program_runtime import Program, Runtime
+
+
+class ProgramTestCase(unittest.TestCase):
+    """Base class for program tests."""
+
+    def setUp(self) -> None:  # noqa: D401 - short description
+        self.runtime = Runtime()
+
+    def register_program(self, name: str, func) -> None:
+        self.runtime.register(name, Program(func))
+
+    def invoke(self, name: str, arg):
+        return self.runtime.invoke(name, arg)
+
+
+__all__ = ["ProgramTestCase"]
+

--- a/python_stubs/programs_bpf_loader/__init__.py
+++ b/python_stubs/programs_bpf_loader/__init__.py
@@ -1,4 +1,28 @@
-"""Python stub for crate `programs/bpf_loader`."""
+"""Simplified loader for BPF like programs.
 
-class Placeholder:
-    pass
+The original crate contains a full blown runtime and a suite of benchmarks.  In
+this stub we only keep enough logic to register binary blobs alongside callable
+Python functions.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ..program_runtime import Program, Runtime
+
+
+class BPFLoader(Runtime):
+    """Runtime that loads programs from raw bytes."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._binaries: Dict[str, bytes] = {}
+
+    def load_program(self, name: str, binary: bytes, func) -> None:
+        self._binaries[name] = binary
+        self.register(name, Program(func))
+
+
+__all__ = ["BPFLoader"]
+

--- a/python_stubs/programs_bpf_loader_gen_syscall_list/__init__.py
+++ b/python_stubs/programs_bpf_loader_gen_syscall_list/__init__.py
@@ -1,4 +1,22 @@
-"""Python stub for crate `programs/bpf_loader/gen-syscall-list`."""
+"""Generate a simple list of system calls.
 
-class Placeholder:
-    pass
+The real utility emits a JSON description of available syscalls.  For testing
+purposes we merely return a static list.
+"""
+
+from __future__ import annotations
+
+
+def generate_syscall_list() -> list[str]:
+    """Return a list of supported syscall names."""
+
+    # This list is purely illustrative and much shorter than the real thing.
+    return [
+        "log",
+        "invoke",
+        "sha256",
+    ]
+
+
+__all__ = ["generate_syscall_list"]
+

--- a/python_stubs/programs_bpf_loader_tests/__init__.py
+++ b/python_stubs/programs_bpf_loader_tests/__init__.py
@@ -1,4 +1,23 @@
-"""Python stub for crate `programs/bpf-loader-tests`."""
+"""Test helpers for :mod:`programs_bpf_loader`.
 
-class Placeholder:
-    pass
+The real crate contains a collection of integration tests.  This module merely
+provides a :class:`BPFLoaderTestCase` base class that can be extended to emulate
+similar behaviour in Python.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from ..programs_bpf_loader import BPFLoader
+
+
+class BPFLoaderTestCase(unittest.TestCase):
+    """Base test case for BPF loader tests."""
+
+    def setUp(self) -> None:
+        self.loader = BPFLoader()
+
+
+__all__ = ["BPFLoaderTestCase"]
+

--- a/python_stubs/programs_compute_budget/__init__.py
+++ b/python_stubs/programs_compute_budget/__init__.py
@@ -1,4 +1,27 @@
-"""Python stub for crate `programs/compute-budget`."""
+"""Simple compute budget tracker.
 
-class Placeholder:
-    pass
+The Rust counterpart defines an on-chain program; this stub merely tracks usage
+locally and can be exercised from unit tests.
+"""
+
+from __future__ import annotations
+
+
+class ComputeBudget:
+    """Keeps track of used compute units."""
+
+    def __init__(self, limit: int):
+        self.limit = limit
+        self.used = 0
+
+    def consume(self, amount: int) -> None:
+        if self.used + amount > self.limit:
+            raise RuntimeError("compute budget exceeded")
+        self.used += amount
+
+    def remaining(self) -> int:
+        return self.limit - self.used
+
+
+__all__ = ["ComputeBudget"]
+

--- a/python_stubs/programs_compute_budget_bench/__init__.py
+++ b/python_stubs/programs_compute_budget_bench/__init__.py
@@ -1,4 +1,24 @@
-"""Python stub for crate `programs/compute-budget-bench`."""
+"""Benchmark helpers for the compute budget program.
 
-class Placeholder:
-    pass
+The original crate exposes criterion based benchmarks.  ``benchmark`` can be
+used to reproduce similar measurements in Python.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+
+def benchmark(func: Callable[[], None], iterations: int = 1) -> float:
+    """Measure average execution time of ``func``."""
+
+    start = time.perf_counter()
+    for _ in range(iterations):
+        func()
+    end = time.perf_counter()
+    return (end - start) / max(iterations, 1)
+
+
+__all__ = ["benchmark"]
+

--- a/python_stubs/programs_ed25519_tests/__init__.py
+++ b/python_stubs/programs_ed25519_tests/__init__.py
@@ -1,4 +1,28 @@
-"""Python stub for crate `programs/ed25519-tests`."""
+"""Light-weight Ed25519 test utilities.
 
-class Placeholder:
-    pass
+The actual Rust crate performs cryptographic signature verification tests.  Here
+we use a very small helper that emulates signing via ``sha512`` so that unit
+tests can verify control flow without additional dependencies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import unittest
+
+
+def _fake_sign(message: bytes) -> bytes:
+    """Return a fake signature using SHA-512."""
+
+    return hashlib.sha512(message).digest()[:64]
+
+
+class Ed25519TestCase(unittest.TestCase):
+    """Base class for Ed25519 related tests."""
+
+    def assertSignatureValid(self, message: bytes, signature: bytes) -> None:
+        self.assertEqual(_fake_sign(message), signature)
+
+
+__all__ = ["Ed25519TestCase", "_fake_sign"]
+

--- a/python_stubs/programs_loader_v4/__init__.py
+++ b/python_stubs/programs_loader_v4/__init__.py
@@ -1,4 +1,21 @@
-"""Python stub for crate `programs/loader-v4`."""
+"""Minimal representation of loader version 4.
 
-class Placeholder:
-    pass
+The real loader is responsible for deploying on-chain programs.  This stub only
+stores the binaries that were "loaded" for use in unit tests.
+"""
+
+from __future__ import annotations
+
+
+class LoaderV4:
+    """Loads programs using the V4 protocol."""
+
+    def __init__(self) -> None:
+        self.loaded = {}
+
+    def load(self, name: str, binary: bytes) -> None:
+        self.loaded[name] = binary
+
+
+__all__ = ["LoaderV4"]
+

--- a/python_stubs/programs_stake/__init__.py
+++ b/python_stubs/programs_stake/__init__.py
@@ -1,4 +1,32 @@
-"""Python stub for crate `programs/stake`."""
+"""Simplified stake program.
 
-class Placeholder:
-    pass
+The real program handles delegation and rewards in the Solana runtime.  The
+implementation here is intentionally tiny and intended purely for unit tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class StakeAccount:
+    owner: str
+    balance: int
+
+
+class StakeProgram:
+    def __init__(self) -> None:
+        self.accounts: dict[str, StakeAccount] = {}
+
+    def create_account(self, name: str, owner: str, balance: int) -> None:
+        self.accounts[name] = StakeAccount(owner, balance)
+
+    def delegate(self, name: str, validator: str) -> None:
+        if name not in self.accounts:
+            raise KeyError("Unknown stake account")
+        self.accounts[name].owner = validator
+
+
+__all__ = ["StakeAccount", "StakeProgram"]
+

--- a/python_stubs/programs_stake_tests/__init__.py
+++ b/python_stubs/programs_stake_tests/__init__.py
@@ -1,4 +1,20 @@
-"""Python stub for crate `programs/stake-tests`."""
+"""Test helpers for the :mod:`programs_stake` module.
 
-class Placeholder:
-    pass
+The original crate defines unit tests for the Solana stake program.  Subclass
+:class:`StakeProgramTestCase` to write equivalent Python tests.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from ..programs_stake import StakeProgram
+
+
+class StakeProgramTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.program = StakeProgram()
+
+
+__all__ = ["StakeProgramTestCase"]
+


### PR DESCRIPTION
## Summary
- flesh out Python stubs for several crates
- add tiny runtime and testing helpers for program stubs
- provide simple benchmark utilities

## Testing
- `python -m compileall -q python_stubs/platform_tools_sdk_gen_headers python_stubs/poh python_stubs/poh_bench python_stubs/poseidon python_stubs/precompiles python_stubs/program_runtime python_stubs/program_test python_stubs/programs_bpf_loader python_stubs/programs_bpf_loader_gen_syscall_list python_stubs/programs_bpf_loader_tests python_stubs/programs_compute_budget python_stubs/programs_compute_budget_bench python_stubs/programs_ed25519_tests python_stubs/programs_loader_v4 python_stubs/programs_stake python_stubs/programs_stake_tests`

------
https://chatgpt.com/codex/tasks/task_e_685cddd6b7ec832097c2c08030b3fb2c