### PR TITLE
Document crate Python stubs

### DIFF
--- a/python_stubs/lattice_hash/__init__.py
+++ b/python_stubs/lattice_hash/__init__.py
@@ -1,4 +1,13 @@
-"""Python stub for crate `lattice-hash`."""
+"""Python stub for crate `lattice-hash`.
+
+The Rust crate implements an incremental lattice based hash using the
+``blake3`` algorithm.  The Python equivalent would expose a ``LtHash``
+class with ``identity()``, ``mix_in()``, ``mix_out()`` and ``checksum()``
+methods.  Refer to ``lattice-hash/src/lt_hash.rs`` for the complete
+implementation.
+"""
 
 class Placeholder:
+    """Placeholder for the LtHash API."""
+
     pass

--- a/python_stubs/ledger/__init__.py
+++ b/python_stubs/ledger/__init__.py
@@ -1,4 +1,12 @@
-"""Python stub for crate `ledger`."""
+"""Python stub for crate `ledger`.
+
+This crate contains the on-disk ledger format and utility functions for
+managing it.  The Python stub does not implement the storage layer but
+serves as a placeholder for APIs such as blockstore access or snapshot
+handling.  See ``ledger/src`` for the full Rust implementation.
+"""
 
 class Placeholder:
+    """Placeholder for ledger utilities."""
+
     pass

--- a/python_stubs/ledger_tool/__init__.py
+++ b/python_stubs/ledger_tool/__init__.py
@@ -1,4 +1,13 @@
-"""Python stub for crate `ledger-tool`."""
+"""Python stub for crate `ledger-tool`.
+
+The ``ledger-tool`` binary provides a command line interface for
+interrogating an on-disk ledger.  In Python this would typically be
+exposed via a ``main()`` function that parses ``argparse`` arguments and
+invokes the relevant ledger operations.  Consult ``ledger-tool/src`` for
+the available subcommands.
+"""
 
 class Placeholder:
+    """Placeholder for CLI entry points."""
+
     pass

--- a/python_stubs/local_cluster/__init__.py
+++ b/python_stubs/local_cluster/__init__.py
@@ -1,4 +1,11 @@
-"""Python stub for crate `local-cluster`."""
+"""Python stub for crate `local-cluster`.
+
+The Rust ``local-cluster`` crate launches an in-process cluster for
+testing.  A Python equivalent would manage validator processes and
+network configuration.  The stub merely marks the module's presence.
+"""
 
 class Placeholder:
+    """Placeholder for cluster helpers."""
+
     pass

--- a/python_stubs/log_analyzer/__init__.py
+++ b/python_stubs/log_analyzer/__init__.py
@@ -1,4 +1,11 @@
-"""Python stub for crate `log-analyzer`."""
+"""Python stub for crate `log-analyzer`.
+
+This binary parses validator log files and produces human readable
+statistics.  A Python version would expose a ``main()`` entry point that
+accepts log file paths and prints summaries similar to the Rust tool.
+"""
 
 class Placeholder:
+    """Placeholder for log analysis helpers."""
+
     pass

--- a/python_stubs/log_collector/__init__.py
+++ b/python_stubs/log_collector/__init__.py
@@ -1,4 +1,11 @@
-"""Python stub for crate `log-collector`."""
+"""Python stub for crate `log-collector`.
+
+The Rust crate streams validator logs to a central service.  A Python
+equivalent might collect logs using ``asyncio`` and forward them to a
+remote endpoint.  This module currently only provides a placeholder.
+"""
 
 class Placeholder:
+    """Placeholder for log collection logic."""
+
     pass

--- a/python_stubs/measure/__init__.py
+++ b/python_stubs/measure/__init__.py
@@ -1,4 +1,11 @@
-"""Python stub for crate `measure`."""
+"""Python stub for crate `measure`.
+
+The ``measure`` crate offers simple timing utilities.  A Python version
+would provide a ``Measure`` context manager capturing elapsed time in
+nanoseconds.  For reference see ``measure/src/measure.rs``.
+"""
 
 class Placeholder:
+    """Placeholder for the Measure API."""
+
     pass

--- a/python_stubs/memory_management/__init__.py
+++ b/python_stubs/memory_management/__init__.py
@@ -1,4 +1,12 @@
-"""Python stub for crate `memory-management`."""
+"""Python stub for crate `memory-management`.
+
+The Rust crate provides helpers for working with aligned memory blocks.
+See ``memory-management/src`` for details.  A Python implementation
+could offer functions like ``is_memory_aligned`` and an ``AlignedMemory``
+class wrapping ``bytearray`` with alignment guarantees.
+"""
 
 class Placeholder:
+    """Placeholder for memory helpers."""
+
     pass

--- a/python_stubs/merkle_tree/__init__.py
+++ b/python_stubs/merkle_tree/__init__.py
@@ -1,4 +1,11 @@
-"""Python stub for crate `merkle-tree`."""
+"""Python stub for crate `merkle-tree`.
+
+The Rust module implements a Merkle tree with proof generation and
+verification.  Python equivalents would expose a ``MerkleTree`` class and
+``Proof`` objects mirroring the API defined in ``merkle-tree/src``.
+"""
 
 class Placeholder:
+    """Placeholder for Merkle tree structures."""
+
     pass

--- a/python_stubs/metrics/__init__.py
+++ b/python_stubs/metrics/__init__.py
@@ -1,4 +1,11 @@
-"""Python stub for crate `metrics`."""
+"""Python stub for crate `metrics`.
+
+Provides datapoint submission helpers and moving statistics.  A Python
+version might integrate with ``logging`` or ``prometheus_client`` to
+record metrics.  See ``metrics/src`` for the original code.
+"""
 
 class Placeholder:
+    """Placeholder for metrics collection."""
+
     pass

--- a/python_stubs/net_shaper/__init__.py
+++ b/python_stubs/net_shaper/__init__.py
@@ -1,4 +1,13 @@
-"""Python stub for crate `net-shaper`."""
+"""Python stub for crate `net-shaper`.
+
+The ``net-shaper`` binary configures traffic shaping rules using system
+utilities such as ``tc`` and ``iptables``.  A Python CLI could provide
+similar functionality via ``subprocess`` calls based on
+``argparse``-parsed options.  See ``net-shaper/src/main.rs`` for the
+reference implementation.
+"""
 
 class Placeholder:
+    """Placeholder for the command-line tool."""
+
     pass

--- a/python_stubs/net_utils/__init__.py
+++ b/python_stubs/net_utils/__init__.py
@@ -1,4 +1,11 @@
-"""Python stub for crate `net-utils`."""
+"""Python stub for crate `net-utils`.
+
+Utility functions used by networking code, including helpers to discover
+public IP addresses and verify reachable ports.  Python implementations
+could use ``socket`` and ``asyncio`` to provide similar capabilities.
+"""
 
 class Placeholder:
+    """Placeholder for networking helpers."""
+
     pass

--- a/python_stubs/notifier/__init__.py
+++ b/python_stubs/notifier/__init__.py
@@ -1,4 +1,11 @@
-"""Python stub for crate `notifier`."""
+"""Python stub for crate `notifier`.
+
+The notifier crate sends notifications about long running tasks.  A
+Python implementation might integrate with ``logging`` or email/SMS
+gateways.  Currently this module only provides a placeholder.
+"""
 
 class Placeholder:
+    """Placeholder for notification helpers."""
+
     pass

--- a/python_stubs/perf/__init__.py
+++ b/python_stubs/perf/__init__.py
@@ -1,4 +1,11 @@
-"""Python stub for crate `perf`."""
+"""Python stub for crate `perf`.
+
+Utilities to gather performance statistics.  In Python this might wrap
+``perf`` or similar system profiling tools.  Refer to ``perf/src`` in the
+Rust workspace for details.
+"""
 
 class Placeholder:
+    """Placeholder for performance measurement."""
+
     pass

--- a/python_stubs/platform_tools_sdk_cargo_build_sbf/__init__.py
+++ b/python_stubs/platform_tools_sdk_cargo_build_sbf/__init__.py
@@ -1,4 +1,12 @@
-"""Python stub for crate `platform-tools-sdk/cargo-build-sbf`."""
+"""Python stub for crate `platform-tools-sdk/cargo-build-sbf`.
+
+This crate provides the ``cargo-build-sbf`` command.  It compiles Rust
+programs using the Solana SBF SDK.  A Python shim could invoke the binary
+via ``subprocess`` or provide equivalent argument handling using
+``argparse``.
+"""
 
 class Placeholder:
+    """Placeholder for the ``cargo-build-sbf`` CLI."""
+
     pass

--- a/python_stubs/platform_tools_sdk_cargo_test_sbf/__init__.py
+++ b/python_stubs/platform_tools_sdk_cargo_test_sbf/__init__.py
@@ -1,4 +1,11 @@
-"""Python stub for crate `platform-tools-sdk/cargo-test-sbf`."""
+"""Python stub for crate `platform-tools-sdk/cargo-test-sbf`.
+
+Implements the ``cargo-test-sbf`` binary that runs Rust tests in the SBF
+environment.  A Python wrapper could call the native tool via
+``subprocess`` with translated arguments.
+"""
 
 class Placeholder:
+    """Placeholder for the ``cargo-test-sbf`` CLI."""
+
     pass


### PR DESCRIPTION
## Summary
- expand docstrings in various python stubs
- clarify their links to the original Rust crates

## Testing
- `python3 -m py_compile $(git ls-files 'python_stubs/**/*.py' | tr '\n' ' ')`

------
https://chatgpt.com/codex/tasks/task_e_685cddd181d883208ebfcfd59cc91a81