### PR TITLE
Add expanded Python stubs

### DIFF
--- a/python_stubs/bloom/__init__.py
+++ b/python_stubs/bloom/__init__.py
@@ -1,4 +1,52 @@
-"""Python stub for crate `bloom`."""
+"""Python bindings for the Rust crate `bloom`.
 
-class Placeholder:
+This module provides lightweight Python representations of the data
+structures exposed by the Rust implementation.  The interfaces mirror the
+original APIs but contain no functionality.
+"""
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+class BloomHashIndex:
+    """Trait implemented by types that can produce stable hashes.
+
+    This mirrors the ``BloomHashIndex`` trait from the Rust crate.
+    """
+
+    def hash_at_index(self, hash_index: int) -> int:
+        """Return a 64‑bit hash for ``hash_index``."""
+        raise NotImplementedError
+
+
+@dataclass
+class Bloom:
+    """Simplified representation of ``Bloom<T>`` from the Rust crate."""
+
+    num_bits: int
+    keys: list[int]
+
+    def add(self, key: BloomHashIndex) -> None:  # noqa: D401
+        """Add ``key`` to the Bloom filter."""
+
+    def contains(self, key: BloomHashIndex) -> bool:  # noqa: D401
+        """Return ``True`` if ``key`` may be in the filter."""
+        return False
+
+    def clear(self) -> None:  # noqa: D401
+        """Reset all bits."""
+
+
+class ConcurrentBloom(Bloom):
+    """Placeholder for ``ConcurrentBloom`` in the Rust crate."""
+
     pass
+
+
+class ConcurrentBloomInterval(ConcurrentBloom):
+    """Wrapper providing periodic clearing of a ``ConcurrentBloom``."""
+
+    def maybe_reset(self, reset_interval_ms: int) -> None:  # noqa: D401
+        """Reset the filter if ``reset_interval_ms`` has elapsed."""
+

--- a/python_stubs/bucket_map/__init__.py
+++ b/python_stubs/bucket_map/__init__.py
@@ -1,4 +1,52 @@
-"""Python stub for crate `bucket_map`."""
+"""Python bindings for the Rust crate `bucket_map`.
 
-class Placeholder:
-    pass
+This stub exposes minimal Python equivalents of types defined in the
+original crate.  The implementations are placeholders.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple, Callable, Any
+
+
+@dataclass
+class BucketMapConfig:
+    """Configuration options matching ``BucketMapConfig`` in Rust."""
+
+    max_buckets: int
+    drives: Optional[List[str]] = None
+    max_search: Optional[int] = None
+    restart_config_file: Optional[str] = None
+
+    @classmethod
+    def new(cls, max_buckets: int) -> "BucketMapConfig":
+        """Create a basic config with ``max_buckets`` only."""
+        return cls(max_buckets=max_buckets)
+
+
+class BucketMap:
+    """Simplified stand‑in for the ``BucketMap`` type."""
+
+    def __init__(self, config: BucketMapConfig) -> None:
+        self.config = config
+
+    def read_value(self, key: bytes) -> Optional[Tuple[List[Any], int]]:
+        """Return the stored value for ``key`` if present."""
+        return None
+
+    def delete_key(self, key: bytes) -> None:  # noqa: D401
+        """Remove ``key`` from the map."""
+
+    def insert(self, key: bytes, value: Tuple[List[Any], int]) -> None:  # noqa: D401
+        """Insert a value associated with ``key``."""
+
+    def try_insert(self, key: bytes, value: Tuple[List[Any], int]) -> bool:  # noqa: D401
+        """Attempt to insert and return ``True`` on success."""
+        return False
+
+    def update(self, key: bytes, updatefn: Callable[[Optional[Tuple[List[Any], int]]], Optional[Tuple[List[Any], int]]]) -> None:  # noqa: D401,E501
+        """Apply ``updatefn`` to the current value for ``key``."""
+
+    def bucket_ix(self, key: bytes) -> int:  # noqa: D401
+        """Return the bucket index for ``key``."""
+        return 0
+

--- a/python_stubs/builtins/__init__.py
+++ b/python_stubs/builtins/__init__.py
@@ -1,4 +1,40 @@
-"""Python stub for crate `builtins`."""
+"""Python interface mirroring the Rust crate `builtins`."""
 
-class Placeholder:
-    pass
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class CoreBpfMigrationConfig:
+    """Configuration describing migration of a builtin program."""
+
+    source_buffer_address: str
+    upgrade_authority_address: Optional[str]
+    feature_id: str
+    verified_build_hash: Optional[str]
+    migration_target: str
+    datapoint_name: str
+
+
+@dataclass
+class BuiltinPrototype:
+    """Represents a builtin program definition."""
+
+    name: str
+    program_id: str
+    entrypoint: str
+    core_bpf_migration_config: Optional[CoreBpfMigrationConfig] = None
+    enable_feature_id: Optional[str] = None
+
+
+@dataclass
+class StatelessBuiltinPrototype(BuiltinPrototype):
+    """Prototype for stateless builtin programs."""
+
+
+BUILTINS: List[BuiltinPrototype] = []
+"""List of builtin program prototypes defined by the Rust crate."""
+
+STATELESS_BUILTINS: List[StatelessBuiltinPrototype] = []
+"""List of stateless builtin prototypes defined by the Rust crate."""
+

--- a/python_stubs/builtins_default_costs/__init__.py
+++ b/python_stubs/builtins_default_costs/__init__.py
@@ -1,4 +1,43 @@
-"""Python stub for crate `builtins-default-costs`."""
+"""Python wrapper for the Rust crate `builtins-default-costs`."""
 
-class Placeholder:
-    pass
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class MigratingBuiltinCost:
+    """Cost information for a builtin that is migrating to core BPF."""
+
+    native_cost: int
+    core_bpf_migration_feature: str
+    position: int
+
+
+@dataclass
+class NotMigratingBuiltinCost:
+    """Cost information for a builtin that is not migrating."""
+
+    native_cost: int
+
+
+class BuiltinCost:
+    """Union of builtin cost types."""
+
+    def __init__(self, migrating: Optional[MigratingBuiltinCost] = None,
+                 not_migrating: Optional[NotMigratingBuiltinCost] = None) -> None:
+        self.migrating = migrating
+        self.not_migrating = not_migrating
+
+
+def get_builtin_instruction_cost(program_id: str, feature_set: object) -> Optional[int]:
+    """Return the default cost for ``program_id``.
+
+    This mirrors ``get_builtin_instruction_cost`` in the Rust crate.
+    """
+    return None
+
+
+def get_builtin_migration_feature_index(program_id: str) -> int:
+    """Return the migration feature index for ``program_id`` or ``0``."""
+    return 0
+

--- a/python_stubs/cargo_registry/__init__.py
+++ b/python_stubs/cargo_registry/__init__.py
@@ -1,4 +1,14 @@
-"""Python stub for crate `cargo-registry`."""
+"""Python representation of the `cargo-registry` service."""
 
-class Placeholder:
-    pass
+class CargoRegistryService:
+    """Mirrors the service defined in the Rust crate."""
+
+    async def run(self) -> None:  # noqa: D401
+        """Start serving requests."""
+
+    async def handle_publish_request(self, request) -> None:
+        """Handle a crate publish request."""
+
+    async def handle_download_crate_request(self, path: str) -> None:
+        """Handle a crate download request."""
+

--- a/python_stubs/clap_utils/__init__.py
+++ b/python_stubs/clap_utils/__init__.py
@@ -1,4 +1,35 @@
-"""Python stub for crate `clap-utils`."""
+"""Python helpers corresponding to the Rust crate `clap-utils`."""
 
-class Placeholder:
-    pass
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+
+@dataclass
+class ArgConstant:
+    """Represents a constant command line argument."""
+
+    long: str
+    name: str
+    help: str
+
+
+class DisplayError(Exception):
+    """Error wrapper mirroring ``DisplayError`` from Rust."""
+
+    def __init__(self, inner: Exception) -> None:
+        super().__init__(str(inner))
+        self.inner = inner
+
+
+def hidden_unless_forced() -> bool:
+    """Return ``True`` if arguments marked hidden should remain hidden."""
+    return True
+
+
+def compute_unit_price_arg() -> Any:
+    """Return the argument definition for compute unit price."""
+
+
+def compute_unit_limit_arg() -> Any:
+    """Return the argument definition for compute unit limit."""
+

--- a/python_stubs/clap_v3_utils/__init__.py
+++ b/python_stubs/clap_v3_utils/__init__.py
@@ -1,4 +1,27 @@
-"""Python stub for crate `clap-v3-utils`."""
+"""Python helpers mirroring the `clap-v3-utils` crate."""
 
-class Placeholder:
-    pass
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class ArgConstant:
+    """Represents metadata for a clap argument."""
+
+    long: str
+    name: str
+    help: str
+
+
+class DisplayError(Exception):
+    """Error wrapper providing ``Display`` semantics."""
+
+    def __init__(self, inner: Exception) -> None:
+        super().__init__(str(inner))
+        self.inner = inner
+
+
+def hidden_unless_forced() -> bool:
+    """Return ``True`` if hidden arguments remain hidden."""
+    return True
+

--- a/python_stubs/cli/__init__.py
+++ b/python_stubs/cli/__init__.py
@@ -1,4 +1,19 @@
-"""Python stub for crate `cli`."""
+"""Python interfaces for the `cli` crate."""
 
-class Placeholder:
-    pass
+def process_command(args: list[str]) -> int:
+    """Entry point matching the Rust CLI.
+
+    Parameters
+    ----------
+    args : list[str]
+        Command line arguments.
+    """
+    return 0
+
+
+class CliConfig:
+    """Configuration options used by the CLI."""
+
+    def __init__(self) -> None:
+        self.rpc_url: str = ""
+

--- a/python_stubs/cli_config/__init__.py
+++ b/python_stubs/cli_config/__init__.py
@@ -1,4 +1,29 @@
-"""Python stub for crate `cli-config`."""
+"""Python stubs mirroring the `cli-config` crate."""
 
-class Placeholder:
-    pass
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Config:
+    """Configuration file structure used by the CLI."""
+
+    json_rpc_url: str
+    keypair_path: str
+
+    @classmethod
+    def load(cls, path: str) -> "Config":  # noqa: D401
+        """Load configuration from ``path``."""
+        raise NotImplementedError
+
+    def save(self, path: str) -> None:  # noqa: D401
+        """Save configuration to ``path``."""
+
+
+def load_config_file(path: str):
+    """Load a YAML config file, mirroring `load_config_file` from Rust."""
+
+
+def save_config_file(config, path: str) -> None:
+    """Write a YAML config file, mirroring `save_config_file` from Rust."""
+

--- a/python_stubs/cli_output/__init__.py
+++ b/python_stubs/cli_output/__init__.py
@@ -1,4 +1,23 @@
-"""Python stub for crate `cli-output`."""
+"""Python API for the ``cli-output`` crate."""
 
-class Placeholder:
-    pass
+from typing import Any
+
+
+class QuietDisplay:
+    """Trait used for quiet display output."""
+
+    def write_str(self, w: Any) -> None:  # noqa: D401
+        """Write the string representation to ``w``."""
+
+
+class VerboseDisplay:
+    """Trait used for verbose display output."""
+
+    def write_str(self, w: Any) -> None:  # noqa: D401
+        """Write the string representation to ``w``."""
+
+
+def build_balance_message(lamports: int, use_lamports_unit: bool, show_unit: bool) -> str:
+    """Create a balance message similar to the Rust implementation."""
+    return ""
+

--- a/python_stubs/client/__init__.py
+++ b/python_stubs/client/__init__.py
@@ -1,4 +1,19 @@
-"""Python stub for crate `client`."""
+"""Python facade for the Rust crate `client`."""
 
-class Placeholder:
-    pass
+from typing import Any
+
+
+class RpcClient:
+    """Wrapper around RPC communication."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+    def send_request(self, method: str, params: Any) -> Any:
+        """Send an RPC request and return the response."""
+        raise NotImplementedError
+
+
+def mock_sender_for_cli() -> None:
+    """Return a mock sender similar to ``mock_sender_for_cli`` in Rust."""
+

--- a/python_stubs/client_test/__init__.py
+++ b/python_stubs/client_test/__init__.py
@@ -1,4 +1,6 @@
-"""Python stub for crate `client-test`."""
+"""Test utilities mirroring the `client-test` crate."""
 
-class Placeholder:
-    pass
+
+def run_tests() -> None:
+    """Execute the client test suite."""
+

--- a/python_stubs/compute_budget/__init__.py
+++ b/python_stubs/compute_budget/__init__.py
@@ -1,4 +1,30 @@
-"""Python stub for crate `compute-budget`."""
+"""Python representation of the `compute-budget` crate."""
 
-class Placeholder:
-    pass
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ComputeBudget:
+    """Compute budget parameters."""
+
+    compute_unit_limit: int
+    log_64_units: int = 0
+
+    def to_budget(self) -> object:
+        """Convert to a Rust-like budget object."""
+        raise NotImplementedError
+
+
+@dataclass
+class ComputeBudgetLimits:
+    """Limits used when creating a compute budget."""
+
+    updated_heap_bytes: int
+    compute_unit_limit: int
+    compute_unit_price: int
+
+    def get_prioritization_fee(self) -> int:
+        """Return the prioritization fee."""
+        return 0
+

--- a/python_stubs/compute_budget_instruction/__init__.py
+++ b/python_stubs/compute_budget_instruction/__init__.py
@@ -1,4 +1,22 @@
-"""Python stub for crate `compute-budget-instruction`."""
+"""Python utilities mirroring the `compute-budget-instruction` crate."""
 
-class Placeholder:
-    pass
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+
+@dataclass
+class ComputeBudgetInstructionDetails:
+    """Details extracted from a set of compute budget instructions."""
+
+    requested_compute_unit_limit: Tuple[int, int] | None = None
+    requested_compute_unit_price: Tuple[int, int] | None = None
+
+    @classmethod
+    def try_from(cls, instructions: Iterable[Tuple[str, bytes]]):  # noqa: D401
+        """Construct from an iterator of instructions."""
+        raise NotImplementedError
+
+    def sanitize_and_convert_to_compute_budget_limits(self, feature_set) -> object:
+        """Sanitize and convert to ``ComputeBudgetLimits``."""
+        raise NotImplementedError
+

--- a/python_stubs/connection_cache/__init__.py
+++ b/python_stubs/connection_cache/__init__.py
@@ -1,4 +1,23 @@
-"""Python stub for crate `connection-cache`."""
+"""Python stubs for the `connection-cache` crate."""
 
-class Placeholder:
-    pass
+from dataclasses import dataclass
+from typing import Any, Dict, Tuple
+
+
+class Protocol:
+    """Enumeration of supported protocols."""
+
+    UDP = "udp"
+    QUIC = "quic"
+
+
+@dataclass
+class ConnectionCache:
+    """Simplified version of the Rust ``ConnectionCache``."""
+
+    name: str
+    connection_pool_size: int = 2
+
+    def update_key(self, key: Any) -> None:  # noqa: D401
+        """Update the connection cache key."""
+

--- a/python_stubs/core/__init__.py
+++ b/python_stubs/core/__init__.py
@@ -1,4 +1,12 @@
-"""Python stub for crate `core`."""
+"""Simplified interfaces matching the `core` crate."""
 
-class Placeholder:
-    pass
+
+class Validator:
+    """Placeholder for the main validator type."""
+
+    def __init__(self, config) -> None:
+        self.config = config
+
+    def start(self) -> None:  # noqa: D401
+        """Start the validator."""
+


### PR DESCRIPTION
## Summary
- expand Python stub files with classes and functions mirroring the Rust APIs for several crates

## Testing
- `python -m py_compile $(git ls-files python_stubs/bloom/__init__.py python_stubs/bucket_map/__init__.py python_stubs/builtins/__init__.py python_stubs/builtins_default_costs/__init__.py python_stubs/cargo_registry/__init__.py python_stubs/clap_utils/__init__.py python_stubs/clap_v3_utils/__init__.py python_stubs/cli/__init__.py python_stubs/cli_config/__init__.py python_stubs/cli_output/__init__.py python_stubs/client/__init__.py python_stubs/client_test/__init__.py python_stubs/compute_budget/__init__.py python_stubs/compute_budget_instruction/__init__.py python_stubs/connection_cache/__init__.py python_stubs/core/__init__.py)`

------
https://chatgpt.com/codex/tasks/task_e_685cddc666a48320bf4a5e362e12fb05