### PR TITLE
Add Python stubs for benchmarking crates

### DIFF
--- a/python_stubs/account_decoder/__init__.py
+++ b/python_stubs/account_decoder/__init__.py
@@ -1,4 +1,79 @@
-"""Python stub for crate `account-decoder`."""
+"""Python stub for crate ``account-decoder``.
 
-class Placeholder:
-    pass
+This module exposes a tiny subset of the helpers provided by the real Rust
+crate.  The Rust crate is responsible for converting on-chain account data into
+a JSON representation returned by RPC calls.  Only the most commonly referenced
+types and helper functions are mirrored here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from account_decoder_client_types import (
+    ParsedAccount,
+    UiAccount,
+    UiAccountData,
+    UiAccountEncoding,
+    UiDataSliceConfig,
+)
+
+StringAmount = str
+StringDecimals = str
+
+MAX_BASE58_BYTES: int = 128
+
+
+def _slice_data(data: bytes, data_slice_config: Optional[UiDataSliceConfig]) -> bytes:
+    """Return ``data`` sliced according to ``data_slice_config``."""
+
+    if data_slice_config is None:
+        return data
+    offset, length = data_slice_config.offset, data_slice_config.length
+    if offset >= len(data):
+        return b""
+    return data[offset : offset + length]
+
+
+def encode_ui_account(
+    pubkey: str,
+    account: "ReadableAccount",
+    encoding: UiAccountEncoding,
+    additional_data: Optional[ParsedAccount] = None,
+    data_slice_config: Optional[UiDataSliceConfig] = None,
+) -> UiAccount:
+    """Encode an account into :class:`UiAccount`.
+
+    The Python version performs no real parsing and simply returns the sliced
+    account data encoded in base64 or base58 depending on ``encoding``.
+    """
+
+    data = _slice_data(account.data, data_slice_config)
+    if encoding in {UiAccountEncoding.BINARY, UiAccountEncoding.BASE58}:
+        import base58
+
+        blob = base58.b58encode(data).decode("ascii")
+        ui_data = UiAccountData(blob, encoding)
+    else:
+        import base64
+
+        blob = base64.b64encode(data).decode("ascii")
+        ui_data = UiAccountData(blob, encoding)
+
+    return UiAccount(
+        lamports=account.lamports,
+        data=ui_data,
+        owner=account.owner,
+        executable=account.executable,
+        rent_epoch=account.rent_epoch,
+        space=len(account.data),
+    )
+
+
+@dataclass
+class UiFeeCalculator:
+    """Simplified version of the Rust ``UiFeeCalculator`` struct."""
+
+    lamports_per_signature: StringAmount = "0"
+

--- a/python_stubs/account_decoder_client_types/__init__.py
+++ b/python_stubs/account_decoder_client_types/__init__.py
@@ -1,4 +1,121 @@
-"""Python stub for crate `account-decoder-client-types`."""
+"""Python stub for crate ``account-decoder-client-types``.
 
-class Placeholder:
-    pass
+This module provides Python representations of the types used by the
+``account-decoder`` crate.  The real crate defines a large collection of
+structures that describe decoded account state returned from Solana RPC
+endpoints.  Only a very small portion is reproduced here to satisfy type
+checking of the Python bindings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional
+
+
+class UiAccountEncoding(Enum):
+    """Enum describing how account data is encoded."""
+
+    BINARY = "binary"
+    BASE58 = "base58"
+    BASE64 = "base64"
+    JSON_PARSED = "jsonParsed"
+    BASE64_ZSTD = "base64+zstd"
+
+
+@dataclass
+class UiDataSliceConfig:
+    """Configuration describing a slice of account data."""
+
+    offset: int
+    length: int
+
+
+class UiAccountData:
+    """Container for account data returned by RPC calls."""
+
+    def __init__(self, raw_data: Any, encoding: UiAccountEncoding) -> None:
+        self.raw_data = raw_data
+        self.encoding = encoding
+
+    def decode(self) -> Optional[bytes]:
+        """Return decoded binary data if possible."""
+
+        if self.encoding in {UiAccountEncoding.BASE64, UiAccountEncoding.BASE64_ZSTD}:
+            import base64
+
+            try:
+                return base64.b64decode(self.raw_data)
+            except Exception:
+                return None
+        if self.encoding == UiAccountEncoding.BASE58:
+            try:
+                import base58
+
+                return base58.b58decode(self.raw_data)
+            except Exception:
+                return None
+        return None
+
+
+@dataclass
+class UiAccount:
+    """Simplified representation of a Solana account."""
+
+    lamports: int
+    data: UiAccountData
+    owner: str
+    executable: bool
+    rent_epoch: int
+    space: Optional[int] = None
+
+
+@dataclass
+class ParsedAccount:
+    """Result of parsing account data on the Rust side."""
+
+    program: str
+    parsed: Any
+    space: int
+
+
+@dataclass
+class UiTokenAmount:
+    """Representation of a token amount with decimal support."""
+
+    amount: str
+    decimals: int
+    ui_amount: Optional[float] = None
+    ui_amount_string: str = ""
+
+    def real_number_string(self) -> str:
+        """Return the amount as a string with decimals."""
+
+        return real_number_string(int(self.amount), self.decimals)
+
+    def real_number_string_trimmed(self) -> str:
+        """Return a trimmed version of :meth:`real_number_string`."""
+
+        if self.ui_amount_string:
+            return self.ui_amount_string
+        return real_number_string_trimmed(int(self.amount), self.decimals)
+
+
+def real_number_string(amount: int, decimals: int) -> str:
+    """Return ``amount`` formatted using ``decimals`` decimal places."""
+
+    if decimals > 0:
+        s = f"{amount:0{decimals + 1}d}"
+        return f"{s[:-decimals]}.{s[-decimals:]}"
+    return str(amount)
+
+
+def real_number_string_trimmed(amount: int, decimals: int) -> str:
+    """Return a trimmed decimal string without trailing zeros."""
+
+    s = real_number_string(amount, decimals)
+    if decimals > 0:
+        s = s.rstrip("0").rstrip(".")
+    return s
+

--- a/python_stubs/accounts_bench/__init__.py
+++ b/python_stubs/accounts_bench/__init__.py
@@ -1,4 +1,27 @@
-"""Python stub for crate `accounts-bench`."""
+"""Python stub for the ``accounts-bench`` executable.
 
-class Placeholder:
-    pass
+The real program benchmarks various account database operations within a
+Solana validator.  The Python version only exposes a :func:`main` function that
+prints out the arguments it would have processed.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point used by the CLI stub."""
+
+    parser = argparse.ArgumentParser(prog="accounts-bench")
+    parser.add_argument("--num_slots", type=int, default=4)
+    parser.add_argument("--num_accounts", type=int, default=10_000)
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--clean", action="store_true")
+    args = parser.parse_args(argv)
+
+    print(
+        "accounts-bench stub: slots=%d accounts=%d iterations=%d clean=%s"
+        % (args.num_slots, args.num_accounts, args.iterations, args.clean)
+    )
+

--- a/python_stubs/accounts_cluster_bench/__init__.py
+++ b/python_stubs/accounts_cluster_bench/__init__.py
@@ -1,4 +1,51 @@
-"""Python stub for crate `accounts-cluster-bench`."""
+"""Python stub for the ``accounts-cluster-bench`` tool.
 
-class Placeholder:
-    pass
+The original utility performs cluster based benchmarking by sending RPC calls
+to a validator.  The Python implementation provides small helper functions used
+by other stubs.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+MAX_RPC_CALL_RETRIES = 5
+
+
+def poll_slot_height(client: Any, retries: int = MAX_RPC_CALL_RETRIES) -> int:
+    """Poll ``client`` until a slot height is returned or ``retries`` expire."""
+
+    while retries > 0:
+        try:
+            return client.get_slot_with_commitment("confirmed")  # type: ignore
+        except Exception:  # pragma: no cover - best effort stub
+            retries -= 1
+            time.sleep(0.1)
+    raise RuntimeError("failed to get slot height")
+
+
+def poll_get_latest_blockhash(client: Any, retries: int = MAX_RPC_CALL_RETRIES) -> Optional[str]:
+    """Poll ``client`` for the most recent blockhash."""
+
+    while retries > 0:
+        try:
+            return client.get_latest_blockhash()  # type: ignore
+        except Exception:
+            retries -= 1
+            time.sleep(0.1)
+    return None
+
+
+def poll_get_fee_for_message(client: Any, message: Any, retries: int = MAX_RPC_CALL_RETRIES) -> tuple[Optional[int], Any]:
+    """Poll ``client`` for the fee of ``message`` and return the blockhash used."""
+
+    while retries > 0:
+        try:
+            fee = client.get_fee_for_message(message)  # type: ignore
+            return fee, getattr(message, "recent_blockhash", None)
+        except Exception:
+            retries -= 1
+            time.sleep(0.1)
+    raise RuntimeError("failed to get fee for message")
+

--- a/python_stubs/accounts_db/__init__.py
+++ b/python_stubs/accounts_db/__init__.py
@@ -1,4 +1,62 @@
-"""Python stub for crate `accounts-db`."""
+"""Python stub for the ``accounts-db`` crate.
 
-class Placeholder:
-    pass
+Only a handful of helper types that are re-exported by the Rust crate are
+represented here.  They are primarily used when interacting with Solana's
+account hash cache tooling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class CacheHashDataFileEntry:
+    """Entry within a cache hash data file."""
+
+    hash: int
+    lamports: int
+    pubkey: str
+
+
+@dataclass
+class ParsedCacheHashDataFilename:
+    """Result returned by :func:`parse_cache_hash_data_filename`."""
+
+    slot_range_start: int
+    slot_range_end: int
+    bin_range_start: int
+    bin_range_end: int
+    hash: int
+
+
+@dataclass
+class CacheHashDataFileHeader:
+    """Header information stored at the start of a cache hash data file."""
+
+    count: int
+
+
+def parse_cache_hash_data_filename(path: str) -> Optional[ParsedCacheHashDataFilename]:
+    """Parse ``path`` into a :class:`ParsedCacheHashDataFilename` if possible."""
+
+    parts = path.split(".")
+    if len(parts) != 5:
+        return None
+    try:
+        slot_range_start = int(parts[0])
+        slot_range_end = int(parts[1])
+        bin_range_start = int(parts[2])
+        bin_range_end = int(parts[3])
+        hash_value = int(parts[4], 16)
+    except ValueError:
+        return None
+    return ParsedCacheHashDataFilename(
+        slot_range_start,
+        slot_range_end,
+        bin_range_start,
+        bin_range_end,
+        hash_value,
+    )
+

--- a/python_stubs/accounts_db_accounts_hash_cache_tool/__init__.py
+++ b/python_stubs/accounts_db_accounts_hash_cache_tool/__init__.py
@@ -1,4 +1,15 @@
-"""Python stub for crate `accounts-db/accounts-hash-cache-tool`."""
+"""Stub for the ``accounts-hash-cache-tool`` binary."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import argparse
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point that mimics the CLI of the Rust tool."""
+
+    parser = argparse.ArgumentParser(prog="accounts-hash-cache-tool")
+    parser.add_argument("path", nargs="?", help="Path to cache hash data")
+    parser.parse_args(argv)
+    print("accounts-hash-cache-tool stub executed")
+

--- a/python_stubs/accounts_db_store_histogram/__init__.py
+++ b/python_stubs/accounts_db_store_histogram/__init__.py
@@ -1,4 +1,15 @@
-"""Python stub for crate `accounts-db/store-histogram`."""
+"""Stub for the ``store-histogram`` utility."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import argparse
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the histogram analysis (stubbed)."""
+
+    parser = argparse.ArgumentParser(prog="store-histogram")
+    parser.add_argument("path", nargs="?", help="Path to account storage")
+    parser.parse_args(argv)
+    print("store-histogram stub executed")
+

--- a/python_stubs/accounts_db_store_tool/__init__.py
+++ b/python_stubs/accounts_db_store_tool/__init__.py
@@ -1,4 +1,15 @@
-"""Python stub for crate `accounts-db/store-tool`."""
+"""Stub for the ``store-tool`` utility."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import argparse
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point mimicking the Rust CLI."""
+
+    parser = argparse.ArgumentParser(prog="store-tool")
+    parser.add_argument("path", nargs="?", help="Storage path")
+    parser.parse_args(argv)
+    print("store-tool stub executed")
+

--- a/python_stubs/banking_bench/__init__.py
+++ b/python_stubs/banking_bench/__init__.py
@@ -1,4 +1,15 @@
-"""Python stub for crate `banking-bench`."""
+"""Stub for the ``banking-bench`` utility."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import argparse
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the banking benchmark (stubbed)."""
+
+    parser = argparse.ArgumentParser(prog="banking-bench")
+    parser.add_argument("--transactions", type=int, default=1000)
+    parser.parse_args(argv)
+    print("banking-bench stub executed")
+

--- a/python_stubs/banking_stage_ingress_types/__init__.py
+++ b/python_stubs/banking_stage_ingress_types/__init__.py
@@ -1,4 +1,21 @@
-"""Python stub for crate `banking-stage-ingress-types`."""
+"""Python representation of ``banking-stage-ingress-types``."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+from typing import Any, List
+
+BankingPacketBatch = List[Any]
+"""Type alias mirroring the Rust ``BankingPacketBatch``."""
+
+
+class BankingPacketReceiver:
+    """Placeholder for the crossbeam receiver used in Rust."""
+
+    def __init__(self) -> None:  # pragma: no cover - simple stub
+        self._queue: list[BankingPacketBatch] = []
+
+    def recv(self) -> BankingPacketBatch:
+        if not self._queue:
+            raise RuntimeError("queue empty")
+        return self._queue.pop(0)
+

--- a/python_stubs/banks_client/__init__.py
+++ b/python_stubs/banks_client/__init__.py
@@ -1,4 +1,36 @@
-"""Python stub for crate `banks-client`."""
+"""Simplified Python port of the ``banks-client`` crate."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+class BanksClientError(Exception):
+    """Error type used by :class:`BanksClient`."""
+
+
+@dataclass
+class TransactionStatus:
+    """Minimal stand in for ``TransactionStatus``."""
+
+    slot: int
+    err: Optional[str] = None
+
+
+class BanksClient:
+    """Very small subset of the async client used in tests."""
+
+    def __init__(self, transport: Any) -> None:  # pragma: no cover - placeholder
+        self._transport = transport
+
+    def send_transaction(self, transaction: Any) -> None:
+        """Pretend to send ``transaction`` to the server."""
+
+        raise BanksClientError("send_transaction not implemented")
+
+    def get_transaction_status(self, signature: str) -> TransactionStatus:
+        """Fetch the status for ``signature``."""
+
+        raise BanksClientError("get_transaction_status not implemented")
+

--- a/python_stubs/banks_interface/__init__.py
+++ b/python_stubs/banks_interface/__init__.py
@@ -1,4 +1,57 @@
-"""Python stub for crate `banks-interface`."""
+"""Python adaptation of the ``banks-interface`` crate."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, List, Optional
+
+
+class TransactionConfirmationStatus(Enum):
+    PROCESSED = "processed"
+    CONFIRMED = "confirmed"
+    FINALIZED = "finalized"
+
+
+@dataclass
+class TransactionStatus:
+    slot: int
+    confirmations: Optional[int]
+    err: Optional[str]
+    confirmation_status: Optional[TransactionConfirmationStatus]
+
+
+@dataclass
+class TransactionSimulationDetails:
+    logs: List[str]
+    units_consumed: int
+    loaded_accounts_data_size: int
+    return_data: Optional[Any]
+    inner_instructions: Optional[Any]
+
+
+@dataclass
+class TransactionMetadata:
+    log_messages: List[str]
+    compute_units_consumed: int
+    return_data: Optional[Any]
+
+
+@dataclass
+class BanksTransactionResultWithSimulation:
+    result: Optional[Any]
+    simulation_details: Optional[TransactionSimulationDetails]
+
+
+@dataclass
+class BanksTransactionResultWithMetadata:
+    result: Any
+    metadata: Optional[TransactionMetadata]
+
+
+class Banks:
+    """Interface describing the RPC methods provided by ``banks-server``."""
+
+    async def send_transaction_with_context(self, transaction: Any) -> None:
+        raise NotImplementedError
+

--- a/python_stubs/banks_server/__init__.py
+++ b/python_stubs/banks_server/__init__.py
@@ -1,4 +1,18 @@
-"""Python stub for crate `banks-server`."""
+"""Minimal stand in for the ``banks-server`` crate."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+from typing import Any
+
+
+class BanksServer:
+    """Server placeholder used during testing."""
+
+    def __init__(self, bank_forks: Any) -> None:  # pragma: no cover - stub
+        self.bank_forks = bank_forks
+
+    def start(self) -> None:
+        """Start the server (no-op in the stub)."""
+
+        print("banks-server stub started")
+

--- a/python_stubs/bench_streamer/__init__.py
+++ b/python_stubs/bench_streamer/__init__.py
@@ -1,4 +1,15 @@
-"""Python stub for crate `bench-streamer`."""
+"""Stub for the ``bench-streamer`` benchmarking tool."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import argparse
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Execute the streaming benchmark (stub)."""
+
+    parser = argparse.ArgumentParser(prog="bench-streamer")
+    parser.add_argument("--duration", type=int, default=5)
+    parser.parse_args(argv)
+    print("bench-streamer stub executed")
+

--- a/python_stubs/bench_tps/__init__.py
+++ b/python_stubs/bench_tps/__init__.py
@@ -1,4 +1,15 @@
-"""Python stub for crate `bench-tps`."""
+"""Stub for the ``bench-tps`` throughput benchmark."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import argparse
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the TPS benchmark (stub)."""
+
+    parser = argparse.ArgumentParser(prog="bench-tps")
+    parser.add_argument("--tx_count", type=int, default=1000)
+    parser.parse_args(argv)
+    print("bench-tps stub executed")
+

--- a/python_stubs/bench_vote/__init__.py
+++ b/python_stubs/bench_vote/__init__.py
@@ -1,4 +1,15 @@
-"""Python stub for crate `bench-vote`."""
+"""Stub for the ``bench-vote`` binary."""
 
-class Placeholder:
-    pass
+from __future__ import annotations
+
+import argparse
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Execute the vote benchmark (stub)."""
+
+    parser = argparse.ArgumentParser(prog="bench-vote")
+    parser.add_argument("--num_producers", type=int, default=1)
+    parser.parse_args(argv)
+    print("bench-vote stub executed")
+


### PR DESCRIPTION
## Summary
- flesh out account decoder client stubs
- implement minimal helper in `account_decoder`
- provide CLI stubs for benchmark tools
- add small data classes and helpers for banks interface modules

## Testing
- `python -m py_compile $(git ls-files 'python_stubs/**/*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cddbfcc908320afcc6a0fc7e61137