### PR TITLE
Implement simplified runtime stubs

### DIFF
--- a/python_stubs/rpc_test/__init__.py
+++ b/python_stubs/rpc_test/__init__.py
@@ -1,4 +1,35 @@
-"""Python stub for crate `rpc-test`."""
+"""Simplified utilities for testing RPC components.
 
-class Placeholder:
-    pass
+This module emulates a very small portion of the Rust `rpc-test` crate.  It
+provides a :class:`MockRPC` object that can register Python callables as RPC
+methods and invoke them synchronously.  Network and concurrency behaviour of the
+original crate are not implemented; this is purely an in‑process dispatcher used
+for unit tests.
+"""
+
+from typing import Any, Callable, Dict
+
+
+class MockRPC:
+    """A tiny in-memory RPC dispatcher used for tests."""
+
+    def __init__(self) -> None:
+        self._handlers: Dict[str, Callable[..., Any]] = {}
+
+    def register(self, method: str, func: Callable[..., Any]) -> None:
+        """Register ``func`` to be called when ``method`` is invoked."""
+
+        self._handlers[method] = func
+
+    def call(self, method: str, *args: Any, **kwargs: Any) -> Any:
+        """Invoke a registered RPC method.
+
+        Raises ``ValueError`` if the method is unknown.
+        """
+
+        if method not in self._handlers:
+            raise ValueError(f"Unknown RPC method: {method}")
+        return self._handlers[method](*args, **kwargs)
+
+
+__all__ = ["MockRPC"]

--- a/python_stubs/runtime/__init__.py
+++ b/python_stubs/runtime/__init__.py
@@ -1,4 +1,61 @@
-"""Python stub for crate `runtime`."""
+"""Minimal runtime environment used by other stubs.
 
-class Placeholder:
-    pass
+The real `runtime` crate in Rust is responsible for executing transactions and
+maintaining account state.  Here we implement a tiny subset of that behaviour
+using pure Python.  The goal is to provide something that higher level stubs
+can interact with when running unit tests.
+
+This implementation keeps state in memory and performs no signature or program
+verification.  It merely tracks account balances and transaction history.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class Account:
+    """In-memory representation of an account."""
+
+    owner: str
+    balance: int = 0
+
+
+@dataclass
+class RuntimeTransaction:
+    """Simple transaction structure used by :class:`Runtime`."""
+
+    sender: str
+    receiver: str
+    amount: int
+
+
+class Runtime:
+    """Very small transaction processor."""
+
+    def __init__(self) -> None:
+        self._accounts: Dict[str, Account] = {}
+        self._history: List[RuntimeTransaction] = []
+
+    def get_balance(self, owner: str) -> int:
+        return self._accounts.get(owner, Account(owner)).balance
+
+    def create_account(self, owner: str, balance: int = 0) -> None:
+        if owner not in self._accounts:
+            self._accounts[owner] = Account(owner, balance)
+
+    def process_transaction(self, tx: RuntimeTransaction) -> bool:
+        sender = self._accounts.get(tx.sender)
+        receiver = self._accounts.get(tx.receiver)
+        if sender is None or sender.balance < tx.amount:
+            return False
+        if receiver is None:
+            receiver = Account(tx.receiver, 0)
+            self._accounts[tx.receiver] = receiver
+        sender.balance -= tx.amount
+        receiver.balance += tx.amount
+        self._history.append(tx)
+        return True
+
+
+__all__ = ["Runtime", "RuntimeTransaction", "Account"]

--- a/python_stubs/runtime_transaction/__init__.py
+++ b/python_stubs/runtime_transaction/__init__.py
@@ -1,4 +1,25 @@
-"""Python stub for crate `runtime-transaction`."""
+"""Utilities for building transactions used by :mod:`runtime`.
 
-class Placeholder:
-    pass
+This module only contains a dataclass representing a transaction.  The real
+Rust crate has additional serialization and verification logic which are not
+reproduced here.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class RuntimeTransaction:
+    sender: str
+    receiver: str
+    amount: int
+
+    def to_dict(self) -> dict:
+        return {"sender": self.sender, "receiver": self.receiver, "amount": self.amount}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "RuntimeTransaction":
+        return cls(data["sender"], data["receiver"], int(data["amount"]))
+
+
+__all__ = ["RuntimeTransaction"]

--- a/python_stubs/send_transaction_service/__init__.py
+++ b/python_stubs/send_transaction_service/__init__.py
@@ -1,4 +1,45 @@
-"""Python stub for crate `send-transaction-service`."""
+"""Asynchronous service for submitting transactions to a :class:`runtime.Runtime`.
 
-class Placeholder:
-    pass
+The original Rust crate provides a complex networking service.  Here we
+implement a much smaller version built on :mod:`asyncio`.  Transactions added to
+the service are processed sequentially using the provided runtime instance.
+"""
+
+import asyncio
+from typing import Optional
+
+from ..runtime import Runtime, RuntimeTransaction
+
+
+class SendTransactionService:
+    """Queue and process transactions asynchronously."""
+
+    def __init__(self, runtime: Runtime) -> None:
+        self.runtime = runtime
+        self._queue: "asyncio.Queue[RuntimeTransaction]" = asyncio.Queue()
+        self._task: Optional[asyncio.Task] = None
+
+    async def _worker(self) -> None:
+        while True:
+            tx = await self._queue.get()
+            self.runtime.process_transaction(tx)
+            self._queue.task_done()
+
+    def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._worker())
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def send(self, tx: RuntimeTransaction) -> None:
+        await self._queue.put(tx)
+
+
+__all__ = ["SendTransactionService"]

--- a/python_stubs/stake_accounts/__init__.py
+++ b/python_stubs/stake_accounts/__init__.py
@@ -1,4 +1,25 @@
-"""Python stub for crate `stake-accounts`."""
+"""Simplified stake account management.
 
-class Placeholder:
-    pass
+The original Rust crate deals with Solana's stake program.  Here we implement a
+very small portion that keeps track of an owner and their staked amount.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class StakeAccount:
+    owner: str
+    stake: int = 0
+
+    def delegate(self, amount: int) -> None:
+        self.stake += amount
+
+    def withdraw(self, amount: int) -> bool:
+        if amount > self.stake:
+            return False
+        self.stake -= amount
+        return True
+
+
+__all__ = ["StakeAccount"]

--- a/python_stubs/storage_bigtable/__init__.py
+++ b/python_stubs/storage_bigtable/__init__.py
@@ -1,4 +1,24 @@
-"""Python stub for crate `storage-bigtable`."""
+"""In-memory Bigtable style key/value store.
 
-class Placeholder:
-    pass
+This module offers a tiny stand-in for the real Bigtable integration used in
+Solana.  Data is stored in nested dictionaries and is lost when the program
+exits.
+"""
+
+from typing import Any, Dict
+
+
+class BigtableStorage:
+    """A very small table store organised by table name."""
+
+    def __init__(self) -> None:
+        self._tables: Dict[str, Dict[str, Any]] = {}
+
+    def put(self, table: str, key: str, value: Any) -> None:
+        self._tables.setdefault(table, {})[key] = value
+
+    def get(self, table: str, key: str) -> Any:
+        return self._tables.get(table, {}).get(key)
+
+
+__all__ = ["BigtableStorage"]

--- a/python_stubs/storage_bigtable_build_proto/__init__.py
+++ b/python_stubs/storage_bigtable_build_proto/__init__.py
@@ -1,4 +1,22 @@
-"""Python stub for crate `storage-bigtable/build-proto`."""
+"""Helper functions for serialising objects to simple dictionaries.
 
-class Placeholder:
-    pass
+The Rust crate contains build scripts that generate protobuf types.  In this
+Python stub we merely convert dataclasses or objects with ``__dict__`` into a
+dictionary so that they can be stored in :mod:`storage_bigtable`.
+"""
+
+from dataclasses import asdict, is_dataclass
+from typing import Any, Dict
+
+
+def build_proto(obj: Any) -> Dict[str, Any]:
+    """Return a dictionary representation of ``obj``."""
+
+    if is_dataclass(obj):
+        return asdict(obj)
+    if hasattr(obj, "__dict__"):
+        return dict(obj.__dict__)
+    raise TypeError("Object is not serialisable")
+
+
+__all__ = ["build_proto"]

--- a/python_stubs/storage_proto/__init__.py
+++ b/python_stubs/storage_proto/__init__.py
@@ -1,4 +1,16 @@
-"""Python stub for crate `storage-proto`."""
+"""Light-weight protocol messages used by :mod:`storage_bigtable`.
 
-class Placeholder:
-    pass
+Only a couple of message types are represented here.  They mirror the data that
+would be stored in Solana's Bigtable instance but omit all protobuf machinery.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class BlockInfo:
+    slot: int
+    block_hash: str
+
+
+__all__ = ["BlockInfo"]

--- a/python_stubs/streamer/__init__.py
+++ b/python_stubs/streamer/__init__.py
@@ -1,4 +1,27 @@
-"""Python stub for crate `streamer`."""
+"""Simple message streaming utilities using :mod:`asyncio` queues."""
 
-class Placeholder:
-    pass
+import asyncio
+from typing import AsyncIterator, List
+
+
+class DataStreamer:
+    """Broadcast messages to multiple subscribers."""
+
+    def __init__(self) -> None:
+        self._subs: List[asyncio.Queue] = []
+
+    def subscribe(self) -> "asyncio.Queue[bytes]":
+        q: "asyncio.Queue[bytes]" = asyncio.Queue()
+        self._subs.append(q)
+        return q
+
+    async def publish(self, data: bytes) -> None:
+        for q in list(self._subs):
+            await q.put(data)
+
+    async def listen(self, q: asyncio.Queue) -> AsyncIterator[bytes]:
+        while True:
+            yield await q.get()
+
+
+__all__ = ["DataStreamer"]

--- a/python_stubs/svm/__init__.py
+++ b/python_stubs/svm/__init__.py
@@ -1,4 +1,34 @@
-"""Python stub for crate `svm`."""
+"""Very small stack based virtual machine.
 
-class Placeholder:
-    pass
+This bears no resemblance to the real SVM used by Solana other than the name.
+It is purely for demonstrating how higher level components might interact with a
+virtual machine implementation in tests.
+"""
+
+from typing import List
+
+
+class VirtualMachine:
+    """Execute simple stack based programs."""
+
+    def __init__(self) -> None:
+        self.stack: List[int] = []
+
+    def push(self, value: int) -> None:
+        self.stack.append(value)
+
+    def add(self) -> None:
+        b = self.stack.pop()
+        a = self.stack.pop()
+        self.stack.append(a + b)
+
+    def sub(self) -> None:
+        b = self.stack.pop()
+        a = self.stack.pop()
+        self.stack.append(a - b)
+
+    def top(self) -> int:
+        return self.stack[-1]
+
+
+__all__ = ["VirtualMachine"]

--- a/python_stubs/svm_callback/__init__.py
+++ b/python_stubs/svm_callback/__init__.py
@@ -1,4 +1,21 @@
-"""Python stub for crate `svm-callback`."""
+"""Callback registry used by :mod:`svm` during tests."""
 
-class Placeholder:
-    pass
+from typing import Any, Callable, Dict
+
+
+class CallbackRegistry:
+    """Register and invoke simple callback functions."""
+
+    def __init__(self) -> None:
+        self._callbacks: Dict[str, Callable[..., Any]] = {}
+
+    def register(self, name: str, func: Callable[..., Any]) -> None:
+        self._callbacks[name] = func
+
+    def invoke(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        if name not in self._callbacks:
+            raise KeyError(name)
+        return self._callbacks[name](*args, **kwargs)
+
+
+__all__ = ["CallbackRegistry"]

--- a/python_stubs/svm_conformance/__init__.py
+++ b/python_stubs/svm_conformance/__init__.py
@@ -1,4 +1,16 @@
-"""Python stub for crate `svm-conformance`."""
+"""Very small conformance testing helpers for :mod:`svm`."""
 
-class Placeholder:
-    pass
+from . import svm  # type: ignore  # circular import is fine for stubs
+
+
+def run_basic_tests() -> bool:
+    """Run a tiny set of tests against the :class:`svm.VirtualMachine`."""
+
+    vm = svm.VirtualMachine()
+    vm.push(1)
+    vm.push(2)
+    vm.add()
+    return vm.top() == 3
+
+
+__all__ = ["run_basic_tests"]

--- a/python_stubs/svm_feature_set/__init__.py
+++ b/python_stubs/svm_feature_set/__init__.py
@@ -1,4 +1,17 @@
-"""Python stub for crate `svm-feature-set`."""
+"""Feature flags used by the :mod:`svm` stub."""
 
-class Placeholder:
-    pass
+from dataclasses import dataclass
+from typing import Set
+
+
+@dataclass
+class FeatureSet:
+    """A collection of enabled feature names."""
+
+    features: Set[str]
+
+    def is_active(self, name: str) -> bool:
+        return name in self.features
+
+
+__all__ = ["FeatureSet"]

--- a/python_stubs/svm_rent_collector/__init__.py
+++ b/python_stubs/svm_rent_collector/__init__.py
@@ -1,4 +1,15 @@
-"""Python stub for crate `svm-rent-collector`."""
+"""Collect rent from accounts over time."""
 
-class Placeholder:
-    pass
+from dataclasses import dataclass
+
+
+@dataclass
+class RentCollector:
+    lamports_per_slot: int
+
+    def collect(self, balance: int, slots: int) -> int:
+        rent = self.lamports_per_slot * slots
+        return max(balance - rent, 0)
+
+
+__all__ = ["RentCollector"]

--- a/python_stubs/svm_transaction/__init__.py
+++ b/python_stubs/svm_transaction/__init__.py
@@ -1,4 +1,18 @@
-"""Python stub for crate `svm-transaction`."""
+"""Transaction types for the :mod:`svm` stub."""
 
-class Placeholder:
-    pass
+from dataclasses import dataclass
+
+
+@dataclass
+class SVMTransaction:
+    program: str
+    data: bytes
+
+    def execute(self, vm) -> None:
+        # In reality this would serialize instructions.  Here we just push bytes
+        # onto the VM stack as integers.
+        for b in self.data:
+            vm.push(b)
+
+
+__all__ = ["SVMTransaction"]

--- a/python_stubs/test_validator/__init__.py
+++ b/python_stubs/test_validator/__init__.py
@@ -1,4 +1,29 @@
-"""Python stub for crate `test-validator`."""
+"""Utility for spinning up an in-process validator for tests."""
 
-class Placeholder:
-    pass
+import asyncio
+from typing import Optional
+
+from validator_py import Validator
+
+
+class TestValidator:
+    """Wrap :class:`validator_py.Validator` with convenience helpers."""
+
+    def __init__(self) -> None:
+        self.validator = Validator()
+        self._task: Optional[asyncio.Task] = None
+
+    def start(self) -> None:
+        self._task = asyncio.create_task(self.validator.start())
+
+    async def stop(self) -> None:
+        if self._task:
+            self.validator.rpc.stop()
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+
+__all__ = ["TestValidator"]


### PR DESCRIPTION
## Summary
- flesh out `rpc-test` mock RPC dispatcher
- implement minimal in-memory runtime
- define `RuntimeTransaction` helpers
- add async send transaction service
- stub stake accounts and bigtable storage
- provide simple SVM utilities and test validator

## Testing
- `python -m compileall python_stubs`

------
https://chatgpt.com/codex/tasks/task_e_685cdddf52148320ae758155234b2ebf