### PR TITLE
Add compute budget instruction parser

### DIFF
--- a/python_stubs/compute_budget_instruction/__init__.py
+++ b/python_stubs/compute_budget_instruction/__init__.py
@@ -14,9 +14,53 @@ class ComputeBudgetInstructionDetails:
     @classmethod
     def try_from(cls, instructions: Iterable[Tuple[str, bytes]]):  # noqa: D401
         """Construct from an iterator of instructions."""
-        raise NotImplementedError
+        details = cls()
+        for idx, (program, data) in enumerate(instructions):
+            if program != "compute_budget":
+                continue
+            if not data:
+                raise ValueError("Invalid instruction data")
+            tag = data[0]
+            if tag == 1:  # SetComputeUnitLimit
+                if len(data) != 5:
+                    raise ValueError("Invalid compute unit limit data")
+                if details.requested_compute_unit_limit is not None:
+                    raise ValueError("Duplicate compute unit limit request")
+                value = int.from_bytes(data[1:], "little")
+                details.requested_compute_unit_limit = (idx, value)
+            elif tag == 2:  # SetComputeUnitPrice
+                if len(data) != 9:
+                    raise ValueError("Invalid compute unit price data")
+                if details.requested_compute_unit_price is not None:
+                    raise ValueError("Duplicate compute unit price request")
+                value = int.from_bytes(data[1:], "little")
+                details.requested_compute_unit_price = (idx, value)
+            else:
+                raise ValueError("Unsupported compute budget instruction")
+        return details
 
     def sanitize_and_convert_to_compute_budget_limits(self, feature_set) -> object:
         """Sanitize and convert to ``ComputeBudgetLimits``."""
-        raise NotImplementedError
+        from ..compute_budget import ComputeBudgetLimits
+
+        cu_limit = 0
+        cu_price = 0
+
+        if self.requested_compute_unit_limit is not None:
+            _, limit = self.requested_compute_unit_limit
+            if limit < 0:
+                raise ValueError("Invalid compute unit limit")
+            cu_limit = limit
+
+        if self.requested_compute_unit_price is not None:
+            _, price = self.requested_compute_unit_price
+            if price < 0:
+                raise ValueError("Invalid compute unit price")
+            cu_price = price
+
+        return ComputeBudgetLimits(
+            updated_heap_bytes=0,
+            compute_unit_limit=cu_limit,
+            compute_unit_price=cu_price,
+        )
 

--- a/tests/test_compute_budget_instruction.py
+++ b/tests/test_compute_budget_instruction.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from python_stubs.compute_budget_instruction import ComputeBudgetInstructionDetails
+from python_stubs.compute_budget import ComputeBudgetLimits
+
+COMPUTE_BUDGET = "compute_budget"
+
+def cu_limit(val: int):
+    return (COMPUTE_BUDGET, b"\x01" + val.to_bytes(4, "little"))
+
+def cu_price(val: int):
+    return (COMPUTE_BUDGET, b"\x02" + val.to_bytes(8, "little"))
+
+def test_try_from_parses_instructions():
+    instructions = [
+        ("other", b"\x00"),
+        cu_limit(5),
+        cu_price(9),
+    ]
+    details = ComputeBudgetInstructionDetails.try_from(instructions)
+    assert details.requested_compute_unit_limit == (1, 5)
+    assert details.requested_compute_unit_price == (2, 9)
+
+def test_try_from_duplicate_error():
+    instructions = [
+        cu_limit(1),
+        cu_limit(2),
+    ]
+    with pytest.raises(ValueError):
+        ComputeBudgetInstructionDetails.try_from(instructions)
+
+def test_sanitize_and_convert():
+    details = ComputeBudgetInstructionDetails.try_from([cu_limit(7), cu_price(3)])
+    limits = details.sanitize_and_convert_to_compute_budget_limits(None)
+    assert isinstance(limits, ComputeBudgetLimits)
+    assert limits.compute_unit_limit == 7
+    assert limits.compute_unit_price == 3


### PR DESCRIPTION
## Summary
- implement `ComputeBudgetInstructionDetails.try_from` for simple parsing of instruction tuples
- add a sanitization method returning `ComputeBudgetLimits`
- create unit tests covering parsing and conversion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f433bbd00832094ce28c8bff23166