### PR TITLE
Add Python stub tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,12 @@ $ python3 scripts/generate_python_stubs.py
 ```
 
 The generated stubs appear in the `python_stubs/` directory and provide placeholder packages mirroring the workspace structure.
+
+## Python tests
+
+Unit tests covering the stub modules live in `tests/` and are executed with `pytest`.
+Run them with:
+
+```bash
+$ pytest
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -ra
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure the stub packages are importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python_stubs"))

--- a/tests/test_account_decoder.py
+++ b/tests/test_account_decoder.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+import base64
+import sys
+import types
+
+fake_base58 = types.SimpleNamespace()
+fake_base58.b58encode = lambda b: b.hex().encode("ascii")
+sys.modules.setdefault("base58", fake_base58)
+
+import base58
+from account_decoder import encode_ui_account, _slice_data
+from account_decoder_client_types import UiAccountEncoding, UiDataSliceConfig
+
+
+@dataclass
+class FakeAccount:
+    lamports: int
+    data: bytes
+    owner: str
+    executable: bool
+    rent_epoch: int
+
+
+def test_slice_data_basic():
+    assert _slice_data(b"abcdef", UiDataSliceConfig(offset=2, length=3)) == b"cde"
+    assert _slice_data(b"abc", UiDataSliceConfig(offset=10, length=2)) == b""
+
+
+def test_encode_ui_account_base64():
+    acc = FakeAccount(1, b"hello", "owner", False, 0)
+    ui = encode_ui_account("pub", acc, UiAccountEncoding.BASE64)
+    assert ui.data.raw_data == base64.b64encode(b"hello").decode("ascii")
+    assert ui.data.encoding == UiAccountEncoding.BASE64
+    assert ui.lamports == 1
+    assert ui.space == 5
+
+
+def test_encode_ui_account_base58_binary():
+    acc = FakeAccount(1, b"hello", "owner", False, 0)
+    ui = encode_ui_account("pub", acc, UiAccountEncoding.BINARY)
+    assert ui.data.raw_data == base58.b58encode(b"hello").decode("ascii")
+    assert ui.data.encoding == UiAccountEncoding.BINARY
+
+
+def test_encode_ui_account_with_slice():
+    acc = FakeAccount(1, b"hello", "owner", False, 0)
+    cfg = UiDataSliceConfig(offset=1, length=3)
+    ui = encode_ui_account("pub", acc, UiAccountEncoding.BASE64, data_slice_config=cfg)
+    assert ui.data.raw_data == base64.b64encode(b"ell").decode("ascii")

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import socket
+
+import download_utils
+
+
+def test_download_genesis_if_missing_no_network(monkeypatch):
+    def fail_socket(*args, **kwargs):
+        raise AssertionError("network call attempted")
+
+    monkeypatch.setattr(socket, "socket", fail_socket)
+    path = Path("genesis.tar.bz2")
+    assert download_utils.download_genesis_if_missing("http://localhost", path, False) == path

--- a/tests/test_remote_wallet.py
+++ b/tests/test_remote_wallet.py
@@ -1,0 +1,20 @@
+from remote_wallet import RemoteWalletManager, Device, RemoteWalletInfo
+
+
+def test_wallet_manager_basic():
+    manager = RemoteWalletManager()
+    assert manager.update_devices() == 0
+    assert manager.list_devices() == []
+
+    manager.devices = [
+        Device(path="/tmp/d1", pubkey="p1"),
+        Device(path="/tmp/d2", pubkey="p2"),
+    ]
+    assert manager.update_devices() == 2
+    infos = manager.list_devices()
+    assert infos == [
+        RemoteWalletInfo("p1", "/tmp/d1"),
+        RemoteWalletInfo("p2", "/tmp/d2"),
+    ]
+    assert manager.get_wallet_info("p2") == RemoteWalletInfo("p2", "/tmp/d2")
+    assert manager.get_wallet_info("missing") is None


### PR DESCRIPTION
## Summary
- test slice and encoding behavior for account_decoder
- check remote_wallet manager stubs
- ensure download_genesis_if_missing makes no network calls
- configure pytest and document test usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4341cd1483208d11ad357ef79897